### PR TITLE
fix: harden CMS links and YouTube embeds

### DIFF
--- a/frontend/components/blocks/big-video-feature.tsx
+++ b/frontend/components/blocks/big-video-feature.tsx
@@ -2,6 +2,7 @@
 
 import { urlFor } from "@/sanity/lib/image";
 import type { PAGE_QUERY_RESULT } from "@/sanity.types";
+import { getYouTubeVideoId } from "@/lib/youtube-video-id";
 import { XIcon } from "lucide-react";
 import { stegaClean } from "next-sanity";
 import Image from "next/image";
@@ -36,38 +37,6 @@ type BigVideoLightboxProps = {
   title?: string;
   titleId: string;
 };
-
-const youtubeHosts = [
-  "youtube.com",
-  "youtube-nocookie.com",
-  "youtu.be",
-] as const;
-
-function getYouTubeVideoId(value?: string | null) {
-  const cleanUrl = stegaClean(value);
-  if (!cleanUrl) return null;
-
-  try {
-    const url = new URL(cleanUrl);
-    const hostname = url.hostname.replace(/^www\./, "");
-
-    if (!youtubeHosts.includes(hostname as (typeof youtubeHosts)[number])) {
-      return null;
-    }
-
-    if (hostname === "youtu.be") {
-      return url.pathname.split("/").filter(Boolean)[0] ?? null;
-    }
-
-    if (url.pathname.startsWith("/embed/")) {
-      return url.pathname.split("/").filter(Boolean)[1] ?? null;
-    }
-
-    return url.searchParams.get("v");
-  } catch {
-    return null;
-  }
-}
 
 function BigVideoLightbox({
   closeRef,
@@ -141,7 +110,7 @@ export default function BigVideoFeature({
   const displayDescription = stegaClean(description)?.trim();
   const displayEyebrow = stegaClean(eyebrow)?.trim();
   const displayTitle = stegaClean(title)?.trim();
-  const videoId = getYouTubeVideoId(youtubeUrl);
+  const videoId = getYouTubeVideoId(stegaClean(youtubeUrl));
   const embedUrl = videoId
     ? `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`
     : null;

--- a/frontend/components/blocks/person-cta.tsx
+++ b/frontend/components/blocks/person-cta.tsx
@@ -1,5 +1,6 @@
 import PortableTextRenderer from "@/components/portable-text-renderer";
 import { Button } from "@/components/ui/button";
+import { getSafeLinkHref } from "@/lib/safe-href";
 import { cn } from "@/lib/utils";
 import { urlFor } from "@/sanity/lib/image";
 import type { PAGE_QUERY_RESULT } from "@/sanity.types";
@@ -72,23 +73,12 @@ function PersonButtons({
       data-sanity={dataAttribute?.("buttons")}
     >
       {buttons.slice(0, 2).map((button, index) => {
-        const href = stegaClean(button.href);
+        const href = getSafeLinkHref(button.href);
         const variant = stegaClean(button.variant);
         const secondary =
           index > 0 || variant === "outline" || variant === "secondary";
 
-        if (!href) {
-          return (
-            <Button
-              className="h-12 w-full rounded-[9px] px-7 text-[0.9375rem] font-semibold sm:w-auto"
-              disabled
-              key={button._key || `broken-button-${index}`}
-              size="lg"
-            >
-              Link Broken
-            </Button>
-          );
-        }
+        if (!href) return null;
 
         return (
           <Button

--- a/frontend/components/blocks/story-feature.tsx
+++ b/frontend/components/blocks/story-feature.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { getSafeLinkHref } from "@/lib/safe-href";
 import { cn } from "@/lib/utils";
 import { urlFor } from "@/sanity/lib/image";
 import type { PAGE_QUERY_RESULT } from "@/sanity.types";
@@ -30,7 +31,7 @@ const storyRichTextComponents: Partial<PortableTextComponents> = {
   },
   marks: {
     link: ({ children, value }) => {
-      const href = stegaClean(value?.href);
+      const href = getSafeLinkHref(value?.href);
       if (!href) return <>{children}</>;
 
       const openInNewTab = stegaClean(value?.openInNewTab);
@@ -67,20 +68,10 @@ function StoryButtons({
       data-sanity={dataAttribute?.("buttons")}
     >
       {buttons.slice(0, 2).map((button, index) => {
-        const href = stegaClean(button.href);
+        const href = getSafeLinkHref(button.href);
         const label = button.text || "Continue";
 
-        if (!href) {
-          return (
-            <Button
-              className="h-12 rounded-[9px] px-7 text-[0.9375rem]"
-              disabled
-              key={button._key || `broken-button-${index}`}
-            >
-              Link Broken
-            </Button>
-          );
-        }
+        if (!href) return null;
 
         return (
           <Button

--- a/frontend/components/rich-text-content.tsx
+++ b/frontend/components/rich-text-content.tsx
@@ -5,6 +5,7 @@ import {
   type PortableTextProps,
 } from "@portabletext/react";
 import { buttonVariants } from "@/components/ui/button";
+import { getSafeLinkHref } from "@/lib/safe-href";
 import { cn } from "@/lib/utils";
 import { stegaClean } from "next-sanity";
 import Image from "next/image";
@@ -106,11 +107,12 @@ export const richTextContentComponents: PortableTextProps["components"] = {
     ),
   },
   marks: {
-    customLink: ({ children, value }) =>
-      value?.href ? (
+    customLink: ({ children, value }) => {
+      const href = getSafeLinkHref(value?.href);
+      return href ? (
         <Link
           className="font-medium text-primary underline decoration-primary/30 underline-offset-4 hover:decoration-primary"
-          href={value.href}
+          href={href}
           rel={value.openInNewTab ? "noopener noreferrer" : undefined}
           target={value.openInNewTab ? "_blank" : undefined}
         >
@@ -118,15 +120,17 @@ export const richTextContentComponents: PortableTextProps["components"] = {
         </Link>
       ) : (
         <span>{children}</span>
-      ),
-    buttonLink: ({ children, value }) =>
-      value?.href ? (
+      );
+    },
+    buttonLink: ({ children, value }) => {
+      const href = getSafeLinkHref(value?.href);
+      return href ? (
         <Link
           className={cn(
             buttonVariants({ variant: getButtonVariant(value.variant), size: "lg" }),
             "my-2 no-underline",
           )}
-          href={value.href}
+          href={href}
           rel={value.openInNewTab ? "noopener noreferrer" : undefined}
           target={value.openInNewTab ? "_blank" : undefined}
         >
@@ -134,7 +138,8 @@ export const richTextContentComponents: PortableTextProps["components"] = {
         </Link>
       ) : (
         <span>{children}</span>
-      ),
+      );
+    },
   },
   types: {
     image: ({ value }) => {
@@ -211,12 +216,13 @@ export const richTextContentComponents: PortableTextProps["components"] = {
     },
     youtube: ({ value }) => {
       const videoId = getYouTubeVideoId(value.url);
+      const fallbackHref = getSafeLinkHref(value.url);
       if (!videoId) {
-        return value.url ? (
+        return fallbackHref ? (
           <p className="mb-4">
             <a
               className="font-medium text-primary underline decoration-primary/30 underline-offset-4 hover:decoration-primary"
-              href={value.url}
+              href={fallbackHref}
               rel="noopener noreferrer"
               target="_blank"
             >

--- a/frontend/lib/safe-href.test.ts
+++ b/frontend/lib/safe-href.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getSafeLinkHref } from "./safe-href";
+
+describe("getSafeLinkHref", () => {
+  it.each([
+    "/",
+    "/loan-options/",
+    "#eligibility",
+    "https://example.com/path",
+    "http://example.com",
+    "mailto:hello@example.com",
+    "tel:+16025550123",
+  ])("accepts supported href %s", (href) => {
+    expect(getSafeLinkHref(href)).toBe(href);
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "data:text/html,unsafe",
+    "relative/path",
+    "www.example.com",
+    "//example.com/path",
+    "/\\evil.example/path",
+    "https:/example.com",
+    "https:\\evil.example/path",
+    "",
+  ])("rejects unsupported href %s", (href) => {
+    expect(getSafeLinkHref(href)).toBeNull();
+  });
+});

--- a/frontend/lib/safe-href.ts
+++ b/frontend/lib/safe-href.ts
@@ -1,0 +1,26 @@
+import { stegaClean } from "next-sanity";
+
+const safeProtocols = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+export function getSafeLinkHref(value: unknown) {
+  if (typeof value !== "string") return null;
+
+  const href = stegaClean(value)?.trim();
+  if (!href) return null;
+  if (
+    href.startsWith("#") ||
+    (href.startsWith("/") && !href.startsWith("//") && href[1] !== "\\")
+  ) {
+    return href;
+  }
+
+  try {
+    const url = new URL(href);
+    if (["http:", "https:"].includes(url.protocol) && !/^https?:\/\//i.test(href)) {
+      return null;
+    }
+    return safeProtocols.has(url.protocol) ? href : null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/lib/youtube-video-id.ts
+++ b/frontend/lib/youtube-video-id.ts
@@ -1,0 +1,40 @@
+const youtubeHosts = [
+  "youtube.com",
+  "m.youtube.com",
+  "youtube-nocookie.com",
+  "youtu.be",
+] as const;
+
+const youtubePathPrefixes = new Set(["embed", "live", "shorts", "v"]);
+const youtubeVideoIdPattern = /^[A-Za-z0-9_-]{11}$/;
+
+export function getYouTubeVideoId(value?: string | null) {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value);
+    const hostname = url.hostname.replace(/^www\./, "");
+
+    if (
+      url.protocol !== "https:" ||
+      !youtubeHosts.includes(hostname as (typeof youtubeHosts)[number])
+    ) {
+      return null;
+    }
+
+    const pathSegments = url.pathname.split("/").filter(Boolean);
+    let videoId: string | null = null;
+
+    if (hostname === "youtu.be") {
+      videoId = pathSegments.length === 1 ? pathSegments[0] : null;
+    } else if (youtubePathPrefixes.has(pathSegments[0] ?? "")) {
+      videoId = pathSegments.length === 2 ? pathSegments[1] : null;
+    } else {
+      videoId = url.searchParams.get("v");
+    }
+
+    return videoId && youtubeVideoIdPattern.test(videoId) ? videoId : null;
+  } catch {
+    return null;
+  }
+}

--- a/studio/big-video-feature.test.mjs
+++ b/studio/big-video-feature.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getYouTubeVideoId as getFrontendVideoId } from "../frontend/lib/youtube-video-id.ts";
+import { getYouTubeVideoId as getStudioVideoId } from "./schemas/blocks/big-video-feature.ts";
+
+const videoId = "dQw4w9WgXcQ";
+const parsers = [getStudioVideoId, getFrontendVideoId];
+
+test("Studio and frontend accept supported YouTube URL forms", () => {
+  const urls = [
+    `https://youtube.com/watch?v=${videoId}`,
+    `https://www.youtube.com/watch?v=${videoId}&t=10`,
+    `https://m.youtube.com/watch?v=${videoId}`,
+    `https://youtube.com/embed/${videoId}`,
+    `https://youtube-nocookie.com/embed/${videoId}`,
+    `https://youtube.com/shorts/${videoId}`,
+    `https://youtube.com/live/${videoId}`,
+    `https://youtube.com/v/${videoId}`,
+    `https://youtu.be/${videoId}?t=10`,
+  ];
+
+  for (const parser of parsers) {
+    for (const url of urls) assert.equal(parser(url), videoId, url);
+  }
+});
+
+test("Studio and frontend reject unsafe or malformed YouTube URLs", () => {
+  const urls = [
+    `https://youtube.com.evil.example/watch?v=${videoId}`,
+    `https://notyoutube.com/watch?v=${videoId}`,
+    `http://youtube.com/watch?v=${videoId}`,
+    "https://youtube.com/watch",
+    "https://youtube.com/watch?v=too-short",
+    "https://youtube.com/shorts/",
+    `https://youtu.be/${videoId}/extra`,
+    "not a URL",
+    "",
+  ];
+
+  for (const parser of parsers) {
+    for (const url of urls) assert.equal(parser(url), null, url);
+  }
+});

--- a/studio/schemas/blocks/big-video-feature.ts
+++ b/studio/schemas/blocks/big-video-feature.ts
@@ -3,30 +3,40 @@ import { defineField, defineType } from "sanity";
 
 const youtubeHosts = [
   "youtube.com",
+  "m.youtube.com",
   "youtube-nocookie.com",
   "youtu.be",
 ] as const;
 
-function getYouTubeVideoId(value?: string) {
+const youtubePathPrefixes = new Set(["embed", "live", "shorts", "v"]);
+const youtubeVideoIdPattern = /^[A-Za-z0-9_-]{11}$/;
+
+export function getYouTubeVideoId(value?: string | null) {
   if (!value) return null;
 
   try {
     const url = new URL(value);
     const hostname = url.hostname.replace(/^www\./, "");
 
-    if (!youtubeHosts.includes(hostname as (typeof youtubeHosts)[number])) {
+    if (
+      url.protocol !== "https:" ||
+      !youtubeHosts.includes(hostname as (typeof youtubeHosts)[number])
+    ) {
       return null;
     }
 
+    const pathSegments = url.pathname.split("/").filter(Boolean);
+    let videoId: string | null = null;
+
     if (hostname === "youtu.be") {
-      return url.pathname.split("/").filter(Boolean)[0] ?? null;
+      videoId = pathSegments.length === 1 ? pathSegments[0] : null;
+    } else if (youtubePathPrefixes.has(pathSegments[0] ?? "")) {
+      videoId = pathSegments.length === 2 ? pathSegments[1] : null;
+    } else {
+      videoId = url.searchParams.get("v");
     }
 
-    if (url.pathname.startsWith("/embed/")) {
-      return url.pathname.split("/").filter(Boolean)[1] ?? null;
-    }
-
-    return url.searchParams.get("v");
+    return videoId && youtubeVideoIdPattern.test(videoId) ? videoId : null;
   } catch {
     return null;
   }

--- a/studio/schemas/blocks/shared/custom-url.ts
+++ b/studio/schemas/blocks/shared/custom-url.ts
@@ -1,5 +1,33 @@
 import { defineField, defineType } from "sanity";
 
+const safeProtocols = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+function validateExternalUrl(value: unknown) {
+  if (typeof value !== "string" || !value.trim()) {
+    return "Add the external URL";
+  }
+
+  const href = value.trim();
+  if (
+    href.startsWith("#") ||
+    (href.startsWith("/") && !href.startsWith("//") && href[1] !== "\\")
+  ) {
+    return true;
+  }
+
+  try {
+    const url = new URL(href);
+    if (["http:", "https:"].includes(url.protocol) && !/^https?:\/\//i.test(href)) {
+      return "Enter a valid URL";
+    }
+    return safeProtocols.has(url.protocol)
+      ? true
+      : "Use an http, https, mailto, or tel URL";
+  } catch {
+    return "Enter a valid URL";
+  }
+}
+
 export default defineType({
   name: "customUrl",
   title: "URL",
@@ -29,6 +57,11 @@ export default defineType({
       title: "External URL",
       type: "string",
       hidden: ({ parent }) => parent?.type !== "external",
+      validation: (rule) =>
+        rule.custom((value, context) => {
+          const parent = context.parent as { type?: string } | undefined;
+          return parent?.type === "external" ? validateExternalUrl(value) : true;
+        }),
     }),
     defineField({
       name: "internal",
@@ -36,6 +69,13 @@ export default defineType({
       type: "reference",
       to: [{ type: "homePage" }, { type: "page" }, { type: "post" }],
       hidden: ({ parent }) => parent?.type !== "internal",
+      validation: (rule) =>
+        rule.custom((value, context) => {
+          const parent = context.parent as { type?: string } | undefined;
+          return parent?.type === "internal" && !value
+            ? "Select the internal page"
+            : true;
+        }),
     }),
     defineField({
       name: "href",


### PR DESCRIPTION
## Summary

- validates CMS-authored link destinations in Studio and at runtime
- suppresses unresolved public CTA buttons
- centralizes safe link handling with focused tests
- supports common YouTube watch, mobile, shorts, live, embed, and short-link URL formats across Studio and frontend parsing

## Stack

PR 5 of 5. Depends on #18 and completes the replacement of the oversized #14.

Its base intentionally targets the preceding stack branch so CodeRabbit reviews only these follow-up fixes. Review and merge the series in order.

## Verification

- `pnpm --dir frontend test -- lib/safe-href.test.ts` (9 files, 41 tests passed)
- `node --test studio/big-video-feature.test.mjs` (2 tests passed)