### PR TITLE
chore: add vendored Next.js agent skills and harden Sanity MCP config

### DIFF
--- a/.agents/skills/next-cache-components-adoption/SKILL.md
+++ b/.agents/skills/next-cache-components-adoption/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: next-cache-components-adoption
+description: >
+  Turn on Cache Components in a Next.js app and resolve the blocking routes it
+  surfaces. Use when the user wants to enable, adopt, or migrate to Cache
+  Components, flip the `cacheComponents` flag, work through a flood of
+  blocking-prerender / instant validation errors, run the
+  `cache-components-instant-false` codemod, or decide between opting routes out
+  with `export const instant = false` and fixing them in place.
+---
+
+# next-cache-components-adoption
+
+Enable Cache Components on an app and walk it to a passing build. This skill sequences the work; per-error recipes live in the dev overlay fix cards and the build's terminal output. The [migrating to Cache Components guide](https://nextjs.org/docs/app/guides/migrating-to-cache-components) is the canonical reference for the concepts and per-API recipes this skill applies — consult it whenever the skill steps reference a pattern (`"use cache"`, `cacheLife`, `<Suspense>` placement, etc.) and you want the full explanation.
+
+## requires
+
+- **App Router project.** Cache Components is an App Router feature; `cacheComponents: true` does nothing for `pages/` routes. If the project has a `pages/` or `src/pages/` tree but no `app/` or `src/app/` tree, stop and tell the user — Pages → App migration is its own project, not part of this skill. A hybrid app (both `pages/` and `app/`) is fine: the flag affects the `app/` routes; `pages/` routes are unaffected and don't need opt-outs.
+
+- **A resolved app directory.** Locate `next.config.{js,ts,mjs,cjs}` first: that's the project root, and an agent invoked from a subdirectory would otherwise test for `app/` against the wrong `cwd` and find nothing. Look for `app/` and `src/app/` under it, and treat every command and glob in this skill as relative to whichever one exists. If both exist, Next.js builds `app/` and never looks at `src/app/`, so its routes are shadowed and unbuilt — tell the user that and ask which tree to migrate instead of picking one.
+
+- **A runnable app.** The whole loop verifies against `next dev` and a browser, so the app has to boot. If it reads a database or required env at import (e.g. an `env.ts` that throws on a missing `DATABASE_URL`), confirm it actually starts — with the real environment, or local data you stand up — before step 1. Adoption can't be verified against an app that won't run.
+
+- **Next.js 16.3 or later.** That release is where the pieces this skill relies on land: top-level `cacheComponents`, `export const instant`, the dev-overlay instant-navigation validation warnings, and the `cache-components-instant-false` codemod. If `next --version` reports below 16.3, upgrade first:
+  - `npx @next/codemod@latest upgrade latest` to apply the version-to-version codemods.
+  - Read the relevant [version upgrade guide](https://nextjs.org/docs/app/guides/upgrading) (e.g. [Version 16](https://nextjs.org/docs/app/guides/upgrading/version-16)) for what the codemod doesn't cover.
+
+- **No incompatible config keys.** `cacheComponents: true` errors on any file that still exports `dynamic`, `revalidate`, or `fetchCache`. **Translate, don't delete.** Each export encodes behavior the route needs to keep doing; migrate each one to its Cache Components equivalent via the [migration guide's per-key sections](https://nextjs.org/docs/app/guides/migrating-to-cache-components#enable-cache-components). The exception is `dynamic = 'force-dynamic'`: under Cache Components every route is already dynamic by default, so the migration guide removes it outright rather than translating it — don't overthink a batch of identical `force-dynamic` deletions. `revalidate` and `fetchCache` still need real translation. If a value can't be cleanly translated yet, leave a `// TODO: Cache Components adoption — restore revalidate = 3600` comment so the loop picks it up. The `cache-components-instant-false` codemod does not touch these.
+
+- **`experimental.dynamicIO` is fatal.** It was renamed to top-level `cacheComponents` and the old key now aborts before any build can run — remove it (or replace with `cacheComponents: true`) first. `experimental.useCache` is still accepted as a deprecated alias; redundant once `cacheComponents: true` is set, so remove it for clarity.
+
+### notes
+
+- **No passing baseline before the flag.** If the app already uses `"use cache"`, the pre-flag build errors with `please enable the feature flag cacheComponents`. Enabling the flag is the first thing you do (in Incremental, before the codemod; in Direct, before fixing routes) — not a thing to do _after_ getting a passing build. Note this in your starting summary so it doesn't read as a regression.
+
+- **Offline docs.** Guide links have offline copies under `node_modules/next/dist/docs/` (bundled since Next.js 16.2), with the directory layout numbered for ordering (e.g. `node_modules/next/dist/docs/01-app/02-guides/migrating-to-cache-components.md`). If you can't predict the numbered prefix, `find node_modules/next/dist/docs -name '<slug>.md'` resolves it. The `/docs/messages/*` error pages are not bundled.
+
+- **Older versions without bundled docs.** Suggest `npx @next/codemod@latest agents-md` to the user before starting: it downloads a version-matched copy to `.next-docs/` and writes an index into `AGENTS.md` / `CLAUDE.md`. It touches files in their repo, so ask first and run it only if they want it.
+
+## the shape of the work
+
+There's one loop: walk the route tree top-down, one feature at a time, adopting each route against `next dev` + a browser. The build is a final check for each feature, not the working surface.
+
+The choice in step 1 is whether to opt every route out of validation first or fix routes as you go. Either way the loop is the same:
+
+- **With a quiet pre-step (Incremental).** Run the codemod to opt every page and layout out of validation. Once you've also fixed what the codemod can't (sync-IO calls, leftover `revalidate`/`dynamic`/`fetchCache` exports), the build passes; you ship that as its own PR and then start the loop — removing one opt-out at a time and adopting that route. This splits the work into small, reviewable PRs.
+- **Without (Direct).** Enable `cacheComponents` and start the loop on whatever the build flags first. Same loop, but every fix sits on one branch until adoption is complete.
+
+In both, the per-route success bar is the same: **dev loop reports no errors AND `next build` passes**. Check in with the user after every feature, and suggest a commit but never make one without their confirmation. Expect to spend most of the time in the loop, not in the pre-step.
+
+## background
+
+`cacheComponents: true` requires every route to be prerenderable. A route that reads request-time data outside `<Suspense>` is "blocking" and fails the build. `export const instant = false` marks a route as allowed to block, which clears it in both dev and build; on a layout it covers the whole subtree during the build, but client navigations still validate each descendant segment on its own. Reads wrapped in a [`"use cache"`](https://nextjs.org/docs/app/api-reference/directives/use-cache) function count as cache boundaries, not blocking reads.
+
+Three classes of blocker come up, usually in this order:
+
+1. **Request-time reads** (`cookies()`, `headers()`, `await params`, `await searchParams`). All four block when awaited at the top of a page or layout. `params` and `searchParams` often get missed because they're not framed as "request data" the way cookies and headers are. The fix is to push the read into a `<Suspense>`-wrapped child — and for `params`/`searchParams`, forward the promise into the child and await it there; don't `await` at the page top.
+2. **Sync-IO at module/render time** (`new Date()`, `Date.now()`, `Math.random()`, `crypto.randomUUID()`). These fail the build even with `instant = false` — the opt-out doesn't suppress them. If they're in a shared layout, they block every route under it. The codemod can't fix them; you have to translate each one by hand before the build can pass (see the [incremental pre-step](#incremental)). Grep the whole repo for these calls before running anything else.
+3. **`"use cache"` files that read request data.** A file with a top-level `"use cache"` directive can't export `instant`; combining the two errors with `Only async functions are allowed to be exported in a "use cache" file.`, which means the directive was wrong for that route. Remove it before running the codemod.
+
+## working surfaces
+
+### finding blocking routes
+
+Prefer `next dev` over `next build` while you work.
+
+- **`next dev`** — the working surface. Visit a route; its blocking errors surface in the dev overlay with full stack traces and fix cards linking the per-error docs. Work one route at a time — errors don't accumulate in one place. The route itself still returns HTTP 200, so read the overlay (or `.next-dev.log`), not status codes. A cleared overlay is one half of calling a route clean — the other half is browser verification (see [step 2](#step-2-the-inner-loop-remove-opt-outs-one-feature-at-a-time)) and a passing build for that route.
+- **`next build`** — detection only. The build is `next dev`'s authoritative check, not its replacement. Use it as the last gate on each feature in the loop (a passing build is part of the per-route success bar) and as the final verification across the whole app. In Incremental, the build also confirms the pre-step (codemod opted every route out, no shared layout still has a sync-IO blocker) before you ship that PR. Don't reach for the build instead of the dev loop while you're working a route — a passing compile doesn't tell you what ended up in the static shell and what streamed. By default the build stops at the first blocking route, so it's also poor for sizing the work. Two flags help when iterating: `--debug-build-paths` builds only the routes you name (comma-separated glob patterns of file paths relative to the project root, e.g. `--debug-build-paths="app/admin/**/page.tsx"` — not URL paths; `--debug-build-paths="app/(marketing)/about/page.tsx"` — not `/about`; `--debug-build-paths="app/admin"` matches nothing and silently builds zero routes), and `--debug-prerender` disables the early exit so the build continues past the first prerender failure, reports every blocking route, and prints a fuller stack trace that names the originating file and line.
+
+Every blocking error has a docs page — open it. Both the dev overlay and the build terminal print a `https://nextjs.org/docs/messages/<slug>` link with each error. That page is the canonical recipe for the fix; the inline message is a summary. Fetch the link for every distinct error you encounter, even if you think you know the pattern — the recipes evolve, and the same error class can have different correct fixes depending on what the route reads. Don't improvise from the inline message alone. (`/docs/messages/*` pages aren't bundled offline; if you have no network, fall back to the per-API guides under `node_modules/next/dist/docs/` and note the limitation when you report back.)
+
+### verifying each fix at runtime
+
+A passing build or a cleared overlay isn't proof the route actually behaves — Cache Components is a runtime concern (a static shell with streamed data). Verify after every fix, not only at the end.
+
+In preference order:
+
+1. **[`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop) — strongly preferred.** Cross-checks `/_next/mcp` against the live browser via `agent-browser` and surfaces both compile and runtime issues in one pass. The diagnostics (React tree, suspense boundaries, console + network) are richer than poking at `next dev` by hand.
+
+   Install it before starting the loop. Don't wait until you hit something `next dev` alone can't explain. Run:
+
+   ```bash
+   npx skills add https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop
+   ```
+
+   The skill states its required `agent-browser` version and walks you through it.
+
+   **Requires Turbopack.** If `package.json`'s `dev` script passes `--webpack`, flag it to the user and ask whether there's a reason to stay on webpack. If not, switch to Turbopack (the Next.js 16.3+ default). If they want to keep webpack, skip this install and use the [build-only loop](#the-loop-build-only-fallback) instead.
+
+   You don't need permission to install `next-dev-loop` itself. It's a tool, like installing a dev dependency. If a user is present, briefly tell them you're installing it for verification. In a non-interactive run (CI, dashboard, sandbox), install it without asking — "can't prompt the user" is not a reason to skip. The only legitimate skip is a real technical blocker: no network, no npm, read-only filesystem, a stated no-new-deps policy, or a webpack-only dev script. If you skip, name the specific blocker in your final report.
+
+2. **A browser you can drive yourself.** Playwright, `agent-browser` directly, any browser-automation tool. Use only when `next-dev-loop` is genuinely blocked. You'll miss the framework-side checks (`/_next/mcp`), so DOM assertions alone don't catch every regression — be more cautious about what you call "verified."
+
+3. **Build-only.** If you can't run a dev server at all, the build is your only signal. `○ (Static)` routes with no `<Suspense>` are fully verified by the build (nothing streamed to test). `◐ (Partial Prerender)` routes are only shell-verified — flag them when you report back.
+
+4. **No tooling at all.** Ask the user to run the dev server (or build) and report what they see, or hand off the milestone you've reached.
+
+## step 1: choose a strategy
+
+Ask the user, in terms of the PRs they want, not the size of the job. Never use the internal labels (Incremental, Direct) when talking to the user — those are your own scaffolding. Ask in terms of PRs and features, e.g.: _"Do you want me to first open a PR that turns on Cache Components and opts every route out of validation, then handle the actual route adoptions feature-by-feature in follow-up PRs? Or do everything on one branch?"_ Even on a tiny app, the incremental path still has value (review-sized PR, revertible, the `// TODO: Cache Components adoption` markers double as your work queue for next session). Don't pick on their behalf.
+
+If there's no user to ask, default to **Incremental** and document the choice.
+
+- **Incremental** — quiet pre-step + the loop. Run the codemod to opt every page and layout out of validation, get the build passing, stop and check in with the user (see [end of the pre-step](#end-of-the-pre-step-check-in)), then enter [step 2's loop](#step-2-the-inner-loop-remove-opt-outs-one-feature-at-a-time) and ship each feature as a follow-up PR.
+- **Direct** — skip the pre-step. Enable `cacheComponents` and go straight to [step 2's loop](#step-2-the-inner-loop-remove-opt-outs-one-feature-at-a-time); the build's blocking routes are the work queue.
+
+### incremental
+
+Before invoking the codemod, fix the two classes of blocker it can't.
+
+1. **Sync-IO at module/render time.** Grep the whole repo for `new Date()`, `Date.now()`, `Math.random()`, and `crypto.randomUUID()` (not only `app/**/layout.{js,jsx,ts,tsx}` — the read might live in any component imported by a layout). Unblock each match with the `await connection()` + `<Suspense>` fix from its `blocking-prerender-*` error card: it defers the value to request time, exactly as it behaved before the migration, so it needs no product decision. Add this exact comment on the line above the `await connection()`:
+
+   ```tsx
+   // TODO: Cache Components adoption. Added to unblock the build: remove this connection() to re-trigger the error and review the fix options.
+   ```
+
+   It shares the `TODO: Cache Components adoption` prefix with the comments the codemod writes, so the check-in grep finds both. Removing the `await connection()` makes the error fire again with its fix cards — the same motion as removing an opt-out in the loop.
+
+2. **Incompatible segment configs.** Grep for `^export const (revalidate|dynamic|fetchCache)` across the app directory and translate per the `requires` note above. The codemod does not touch them; leaving them in place fails the build after the codemod.
+
+The codemod refuses to run on a dirty working tree. Commit or stash unrelated work first, or pass `--force` to let its edits land alongside your WIP. Common false positive: if you recently upgraded Next.js, `package.json` and the lockfile will already be dirty — commit those first.
+
+```bash
+npx @next/codemod@latest cache-components-instant-false ./app
+```
+
+Pass the app directory you resolved in [requires](#requires). A wrong path is not an error: it reports `0 ok` and exits `0`, so read the file count and treat zero as a failed run, not an adopted app.
+
+Inserts `export const instant = false` (with a `// TODO: Cache Components adoption` comment) into every `{page,layout,default}` file under that directory, skipping files that already declare `instant` and any module marked `"use client"` or `"use server"`. Then set `cacheComponents: true`. The TODO comments are the work queue for the loop.
+
+If the codemod isn't available (older `@next/codemod`, sandboxed environment, offline run), reproduce it by hand: for every `{page,layout,default}.{js,jsx,ts,tsx}` in the app directory that isn't `"use client"` or `"use server"` and doesn't already declare `instant`, insert this after the imports:
+
+```ts
+// TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
+// See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
+export const instant = false
+```
+
+The codemod opts every segment out, not only the root, on purpose. Resolution is top-down, first-explicit-config-wins: the highest `instant = false` decides the whole subtree. With an opt-out on every segment, removing one segment's opt-out validates only that segment; descendants keep their own opt-outs and stay passing. If only the root were opted out, removing it would re-arm validation for the entire app at once.
+
+Because the highest opt-out wins, remove them top-down (root layout first, then descend). Removing a leaf's opt-out does nothing while an ancestor still holds one.
+
+Confirm the pre-step with `next build`. The build is the proof, not the codemod run — a shared layout that calls `new Date()` / `Math.random()` directly still fails regardless of the opt-out (see [background](#background)).
+
+After the build passes, confirm the root layout got an opt-out (`grep -n "export const instant" <app dir>/layout.*`). The root layout renders every route, including framework routes like `/_not-found`, so if it was missed, add `export const instant = false` to it by hand.
+
+Synthetic routes like `/_not-found` have no user file — when they block, fix the root layout's opt-out, not the synthetic route. Client Components (`"use client"`) get no opt-out (it's a build error — `E1344` — to export `instant` from them), but they are not a rare blocker. The high-frequency case is a client component in the root layout's nav or header calling `usePathname()`/`useSearchParams()`: it blocks _every_ dynamic route with `blocking-prerender-client-hook`, and static routes pass (the pathname is known at prerender), which masks it until you reach a dynamic segment. It's not an ancestor-data fix — follow the [error's docs page](https://nextjs.org/docs/messages/blocking-prerender-client-hook) for the `<Suspense>` recipe. Only when a client route blocks on _server_ data do you fix that data in its ancestor.
+
+### end of the pre-step: check in
+
+Incremental only. Stop here before starting step 2 — the pre-step is the shippable PR. Talk to the user in their language; don't say "Incremental" or other internal labels; talk about adoption, PRs, and what the app does now. Tell them:
+
+- What you did: turned on Cache Components, ran the codemod that opts every page and layout out of the new validation (or did it by hand), fixed any blockers the codemod can't (list them), confirmed the build passes.
+- What changed: every page and layout in the app directory now exports `instant = false` with a `// TODO: Cache Components adoption` comment, except client components and any that already had an `instant` export.
+- What to sanity-check: the diff is mostly mechanical (new exports + comments). The build passes. Routes still behave exactly as they did before — the opt-outs preserve current behavior; no rendering changes yet.
+- The question: "Want to open this as its own PR before we start adopting Cache Components route by route? Or keep going on this branch?" Wait for the answer.
+
+Moving to step 2 without checking in defeats the point of taking the incremental path.
+
+### direct
+
+Set `cacheComponents: true` and move to [step 2](#step-2-the-inner-loop-remove-opt-outs-one-feature-at-a-time). The build's blocking routes are the work queue.
+
+## step 2: the inner loop, remove opt-outs one feature at a time
+
+A "feature" is a single product surface — `app/settings/profile/**`, `app/posts/[slug]/**` — not a whole top-level app like `app/dashboard/**`. Finish one end-to-end before starting the next.
+
+Within a feature, walk top-down (layouts before pages, root layout first). Removing a layout's opt-out before its descendants exposes the layout's own blocking reads. (Direct: there are no opt-outs to remove — fix each failing route; if a hand-written opt-out on an ancestor shadows it, remove that first.)
+
+A passing build mid-walk doesn't mean the layout is clean. Removing a layout's opt-out while its descendant pages still have theirs keeps the build passing — each page shadows the inherited validation. The layout's actual blocking reads only surface once nothing below it shadows them. Don't call a feature done at the layout boundary.
+
+Use the **with-a-browser** loop unless a browser is genuinely unreachable. The [`next-dev-loop`](#verifying-each-fix-at-runtime) skill is the source of truth for what counts as "browser available" and how to install it.
+
+### the loop, with a browser (preferred)
+
+Per route:
+
+- Remove the opt-out (Incremental) or target the failing route (Direct).
+- Reload in dev. Overlay clean? Skip to verify. Overlay still red? Fix.
+- Fix — fetch the docs page linked from the error (`https://nextjs.org/docs/messages/<slug>`), apply the recipe from there. The inline overlay text is a summary; the docs page is the source of truth.
+- Verify in the browser. Confirm the visible content on first paint is what you intended in the shell — not stuck on a fallback, not silently streaming everything out of an empty shell.
+- Re-check siblings if the fix touched shared code (a layout, a sidebar component). A shared-shell change can fix the route you're on and break a sibling.
+
+### the loop, build-only (fallback)
+
+Used when there's no way to drive a browser — CI, sandbox, the user has no `next dev` running and you can't start one. Weaker signal: confirms the build passes and the route prerenders, but not what ended up in the static shell vs streamed.
+
+Per route:
+
+- Remove the opt-out (Incremental) or target the failing route (Direct).
+- Rebuild with `--debug-build-paths app/<route>/**` (only that route) or `--debug-prerender` (full build, but past the first failure). Route passing? Move on. Still blocking? Fix.
+- Fix — fetch the docs page linked from the error (`https://nextjs.org/docs/messages/<slug>`), apply the recipe from there.
+- Re-check siblings if the fix touched shared code.
+- Flag the route as build-only-verified when you hand the feature off. Each `◐` route still needs a browser pass before the feature is done.
+
+### loop notes
+
+- The [three blocker classes from background](#background) often get missed when fixing in place. Caching a downstream fetch (`getThing(id)`) doesn't clear an `await params` at the top of the page body — push the param promise into the `<Suspense>`-wrapped child.
+- Ambiguous calls are user check-ins, not agent judgment. When you're not sure which fix fits, the blocking code looks security-sensitive, or the user might want to keep the route blocking on purpose — read [references/per-page-decisions.md](./references/per-page-decisions.md) before editing. Show the route while you ask: the `next-dev-loop` session runs the browser headed, so drive to the page and leave it on screen so the user is looking at the thing they're deciding about, with a screenshot as the fallback when a headed browser isn't possible. "Should this stay blocking?" is much easier to answer while looking at the page than at a file path.
+- Don't narrate the refactor with comments. The only comment the codemod (or you) should leave is `// TODO: Cache Components adoption` on opt-outs, and the user's existing comments. Don't annotate every `<Suspense>` boundary or `"use cache"` call with what it does — the code says that. Drop a comment only when the _why_ isn't clear from the code (e.g. a deliberate Block with a reason).
+- For many routes with the same mechanical fix, verify one representative route first. Then batch disjoint route groups using the same recipe, and run the shared build and browser checks together.
+
+Keep a todo list of the feature's routes. When every route in the feature is clean, move to step 3.
+
+## step 3: verify the feature
+
+Checklist before checking in with the user:
+
+- `next build` completes without blocking-route errors.
+- No bare TODOs in the feature: `grep -rn "TODO: Cache Components adoption"` finds both the codemod's opt-out comments and the sync-IO unblocks from the pre-step. Any `instant = false` left behind is a deliberate, documented Block — comment rewritten to a reason (see [references/per-page-decisions.md](./references/per-page-decisions.md) → "when to leave a Block in place"). Any `await connection()` left behind has been reviewed and kept on purpose, not left over from the pre-step.
+- Each route visited in the browser: confirm the static shell renders first and every `<Suspense>` fallback resolves to its real content. Capture both states if you can — the fallback (mid-stream) and the final paint — so you have a streaming-experience demo to show the user. Throttle the network in the browser if streaming is too fast to observe.
+- If runtime verification fails, reproduce the same route on the pre-adoption branch or with its opt-out restored. A failure that already exists is an environment or data problem, not an adoption regression.
+
+Then check in with the user. Same rule as the pre-step: speak their language. Don't say "feature-by-feature loop" or other internal labels; talk about the feature you adopted and what the user will see.
+
+- What you did: which routes you touched, and the user-visible result per route (e.g. "the post page now streams the article body behind a skeleton while the layout stays static").
+- What changed: opt-outs removed, fallbacks added, caching boundaries introduced.
+- Show, don't tell. The `next-dev-loop` session runs the browser headed, so drive the route live for the user so they see the static shell → fallback → final content sequence in real time. If you can't drive a live browser, attach the before/after screenshots you captured instead.
+- Give them the click-through: a short table of the feature's routes — the URL to open and what to look for (what renders instantly, which fallbacks appear, what streams in) — so they can verify each one themselves.
+- The question: "Want to open this feature as a PR and move on to the next, or stop here?" Wait for the answer.
+
+**Trivial features can skip the check-in.** If adopting a feature only meant removing its `// TODO: Cache Components adoption` opt-out (no `<Suspense>` added, no `'use cache'` introduced, no render order change), the user sees nothing different. Move on to the next feature without stopping; mention it in passing the next time you do check in.
+
+When the loop has run on every feature — every remaining `instant = false` sits under a reason comment, `grep -rln "TODO: Cache Components adoption" app` returns nothing — point the user at [further reading](#further-reading) if they want to push the experience further, or stop and ship.
+
+### route table glyphs
+
+`ƒ` → `◐` is where adoption usually lands. `◐ (Partial Prerender)` means a static shell prerenders and the request-time content streams in — the goal state for any route that reads `cookies()`, `headers()`, `params`, or `searchParams`. Some routes legitimately stay `ƒ` when they do request-time work through a documented escape hatch (e.g. a layout that uses `await connection()`); the page is no longer _opted out_, it's genuinely dynamic. Don't remove the escape hatch only to chase a `◐`. The inverse holds: `instant = false` does not force a route to be `ƒ`. The glyph reflects what the route does at prerender time, not which validation knobs it exports.
+
+`◐` tells you a shell exists, not what's in it. A `<Suspense>` boundary placed too high (e.g. wrapping the entire page body, or `<Suspense fallback={null}>` around the article content) pushes the visible content out of the static shell into the streamed payload; the build still reports `◐` because _some_ shell prerendered (often only `<html><body>` with framework markup). The route table can't tell you what's in the shell; a browser can. If the shell is empty and everything streams, pull the `<Suspense>` boundary down closer to the actual dynamic read.
+
+## further reading
+
+The work below is optional and lives in the docs — link the user to them and let them decide which to take on next. Don't walk these through inside this skill.
+
+- [Sweep for more instant navigations](./references/dev-only-validations.md) — an optional follow-up once adoption is done, never required. A passing build is not the last word, because dev validates every route on each page load (simulating both page loads and client navigations) and catches what the build's first-error exit and descendant shadowing skipped. Offer it as the smaller path to instant navigation for a user who doesn't want to adopt Partial Prefetching. Adopting Partial Prefetching (below) runs the same kind of loop and meets these insights anyway, so recommend both and let the user pick which, or whether. The reference is the loop to execute.
+- [`next-partial-prefetching-adoption`](https://github.com/vercel/next.js/tree/canary/skills/next-partial-prefetching-adoption) — the follow-up skill that adopts Partial Prefetching: it enables `partialPrefetching` and audits every `<Link prefetch={true}>` against a decision table (or adopts incrementally with the flag off, driven by the `link-prefetch-partial` insight). It sequences this the same way this skill sequences Cache Components, but the insights are dev-only, so it's a browser click-through, not a build loop. Recommended after instant navigation, since those fixes feed directly into how much of each route the shell can prefetch. Concepts live in the [Adopting Partial Prefetching guide](https://nextjs.org/docs/app/guides/adopting-partial-prefetching).
+- [Prevent regressions with e2e tests](https://nextjs.org/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests) — the `@next/playwright` [`instant()`](https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config/instant#testing-instant-navigation) helper asserts on the UI that's available immediately on navigation, so regressions surface in CI. Recommend it once a route is instant: `next-dev-loop` confirms it _now_; an `instant()` test keeps it that way.
+- [`next-cache-components-optimizer`](https://github.com/vercel/next.js/tree/canary/skills/next-cache-components-optimizer) — a separate skill that grows each route's static shell so more of the page prerenders and less streams in. Pure optimization, not part of adoption.

--- a/.agents/skills/next-cache-components-adoption/references/dev-only-validations.md
+++ b/.agents/skills/next-cache-components-adoption/references/dev-only-validations.md
@@ -1,0 +1,29 @@
+# dev-only validation sweep
+
+How to surface and fix the instant-navigation insights that a clean `next build` does not show. The [Instant navigation guide](https://nextjs.org/docs/app/guides/instant-navigation) is the canonical reference for the validation model this exercises.
+
+## what the build misses
+
+By default (`validationLevel: 'warning'`) Cache Components validates every Page and Default segment in `next dev`, and the insights land in the dev overlay's Insights tab, not the build. Validation runs on every page load using the real request, and for each route it independently checks the initial page load and client navigations at different points in the hierarchy. So a `<Suspense>` boundary that covers the page load can still leave a client navigation blocking, and a layout stays clean at build time while a descendant keeps its `instant = false`. The build stops at the first blocking route and does not raise this family by default. Loading each route in dev is what surfaces it.
+
+## when to run it
+
+After the Cache Components build is clean, not before. While the app is mid-adoption the build redboxes mask this, so a full clean build (every route `◐`, no errors) is the precondition. A quiet sweep is the expected result of a clean adoption, not a missing signal.
+
+## the loop
+
+Reuse the [`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop) preflight (Turbopack), then add one job. On a webpack app, drive a browser directly with `agent-browser` or Playwright instead. You lose the `/_next/mcp` cross-checks, not the insights, which still show in the overlay and the dev log.
+
+1. Build a route queue from the last build's route table or the app directory.
+2. Load each route in `next dev` with a browser. A refresh or a link click both work, and validation simulates both the page-load and client-navigation cases on that load, so you do not need to click through every link by hand. Dynamic params are checked against the real values you visit, so hit a concrete `[slug]`, not the pattern.
+3. Watch the dev log and the Insights tab. The dev log is the greppable record, one `Error: Route "...": Next.js encountered ...` line per insight with its `docs/messages/<slug>` link, and it reads the same on Turbopack and webpack. The Insights tab is amber and appears only once an insight fires, so a route with no tab is clean. Through `next-dev-loop`'s `/_next/mcp`, these come from `get_errors` and the overlay, not `get_request_insights`, which is the performance recorder and reports nothing here.
+4. Open the linked page for each distinct insight and apply its fix (usually pull a `<Suspense>` boundary down to the read). Reload to confirm it clears.
+
+## gotchas
+
+- The overlay renders inside a shadow root (`nextjs-portal`), so accessibility-tree snapshots miss it. Read it through `shadowRoot`.
+- No browser, no sweep. There is no build-only fallback for this family. Apply the static fix you can from the docs page (gate on type-check) and hand off the live confirmation.
+
+## when this shrinks
+
+Build-time instant validation is opt-in today (`experimental.instantInsights.validationLevel: 'experimental-error'`); the default `'warning'` surfaces in the overlay only. Once the build raises these reliably, the sweep collapses into reading `next build` output and this reference can shrink to that.

--- a/.agents/skills/next-cache-components-adoption/references/per-page-decisions.md
+++ b/.agents/skills/next-cache-components-adoption/references/per-page-decisions.md
@@ -1,0 +1,27 @@
+# per-page decisions: removing `instant = false`
+
+Read this when a route still blocks after you remove its `instant = false` and the dev overlay's fix card isn't enough on its own. Each section here covers a judgment call the agent shouldn't make alone.
+
+## deciding what to do with a blocking read
+
+Read the full linked page behind the fix card — not only the inline snippet — before editing. The card unblocks the build, but the page covers the details that make the route's navigation actually instant (e.g. where to place a `<Suspense>` boundary). Don't improvise.
+
+If you're unsure which fix fits, the right call usually depends on what this part of the page is _for_, which the code doesn't capture. Ask the user about their goal for it rather than guessing. Frame it as a product/UX question: should this content be there instantly on load, or is it fine for it to stream in a moment later? Should everyone see the same thing (cacheable) or is it per-user / per-request? Tie the technical fix to that answer (cache it, wrap it in `<Suspense>`, or keep it request-time), so they're deciding the experience, not the API.
+
+## security gates and other code you can't infer
+
+If the blocking code looks like it's there for a _reason you can't infer_ — a security gate at the page top (`await verifyAccess()`, an auth redirect, a feature-flag check) where moving it inside `<Suspense>` would change what the code guarantees — stop and ask the user before refactoring. The build error wants `<Suspense>`, but wrapping a gate in `<Suspense>` defeats the gate. Only the person who wrote it knows whether to keep the route blocking (`instant = false` as a documented Block), restructure the page so the gate runs differently, move the check to [Proxy](https://nextjs.org/docs/app/api-reference/file-conventions/proxy), or — if the gate duplicates protection the app already relies on elsewhere (platform auth such as Vercel Deployment Protection, a Proxy check, a Data Access Layer) — remove it.
+
+Relocating a read (`await connection()`, Proxy) only changes _where_ it runs, never _whether it should run at all_ — so a gate that's redundant or broken looks identical to a correctly-placed one through the fix card's lens. If a gate looks strange, redundant, or out of place, say so plainly — "this looks like it might be unnecessary here — are you sure it belongs?" — instead of quietly relocating it. Surfacing the doubt is the agent's job; deciding is the user's.
+
+If _every_ route under a layout is gated this way, a documented Block on the layout is the correct end state. Moving the gate to [Proxy](https://nextjs.org/docs/app/api-reference/file-conventions/proxy) is the architectural fix, not a Cache Components one, and that's a follow-up rather than something to hold the migration on.
+
+For the broader picture, read the [Authentication guide](https://nextjs.org/docs/app/guides/authentication) (where auth checks belong: Proxy for routing, Data Access Layer for data) and the [Data Access Layer section of Data Security](https://nextjs.org/docs/app/guides/data-security#data-access-layer) (centralized auth checks that compose with `'use cache'`).
+
+If you don't know how to make a piece of code Cache Components–correct without changing what it does, ask.
+
+## when to leave a Block in place
+
+If a route is genuinely meant to block — it's inherently per-request with no useful static shell — or the refactor would be large and the user would rather not take it on now, that's a legitimate outcome. Keep `instant = false`, but confirm it with the user first and turn its `// TODO: Cache Components adoption` comment into a reason, e.g. `// instant = false: kept on purpose — fully request-time dashboard` or `// instant = false: deferred, refactor too large for now`.
+
+A documented, deliberate Block is fine to leave after the migration; an undocumented leftover opt-out is not.

--- a/.agents/skills/next-cache-components-optimizer/SKILL.md
+++ b/.agents/skills/next-cache-components-optimizer/SKILL.md
@@ -1,0 +1,477 @@
+---
+name: next-cache-components-optimizer
+description: >
+  Drive a Next.js route to instant navigation by setting up an agentic loop,
+  under Cache Components / PPR, on initial load (hard navigation) and
+  client-side navigation (soft navigation). Encode the goal as a failing
+  @next/playwright instant() e2e and work it to green, one verified route at a
+  time; the shipped test then guards against regression. Use when asked to make
+  a route's navigation instant (its static shell commits immediately), fix a
+  route whose static shell isn't prerendered/served/prefetched, grow a route's
+  static shell or fix its slow first paint, diagnose which Suspense boundary
+  keeps a route out of its static shell, or write the instant() e2e guard for
+  one. Requires Next.js 16.3+ with cacheComponents; directs an upgrade if older.
+---
+
+# next-cache-components-optimizer
+
+Set up an agentic optimization loop that drives a Next.js route from "not
+instant" to "instant" and keeps it there. The loop is test-driven: encode the
+goal as a failing `@next/playwright` `instant()` test, work it to green, and
+ship the test as the regression guard. Run it once per target route. Work the
+phases P → G in order; each ends in a gate. Fix recipes live in two lazily-read
+references — `reference/patterns.md` (before→after for each blocker type) and
+`reference/real-app-patterns.md` (parallel routes, auth gates, the empty-shell
+and responsive-skeleton failure modes). Read one only when its phase points
+there.
+
+## What is invariant, and what is yours
+
+One thing here is fixed. The rest is yours. Read this before treating any
+command, platform, or env var below as a requirement.
+
+- **Invariant: the verification loop.** Maximizing the shell is worthless
+  unless you can prove it. The proof is an automated check: under a lock that
+  gates dynamic data, the static shell still commits. RED shows the gap, GREEN
+  shows it closed, the test ships as the regression guard. It must run on a
+  production-like build and must not be able to pass vacuously. Stand the loop
+  up once; every later optimization is then verifiable by construction. The
+  loop is the deliverable, not any one route.
+- **The mechanism: `@next/playwright` `instant()`.** This skill uses
+  [`instant()`](https://nextjs.org/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests)
+  as a ruler, not a stopwatch (phase A). It comes from
+  `@next/playwright` (installed alongside `@playwright/test`, on the same
+  release line as `next`), so it isn't tied to any host. Keep it. Timing a
+  navigation by hand is too flaky to trust, and is the failure mode this skill
+  exists to prevent.
+- **Yours: the rig.** How you build, deploy, authenticate, configure
+  Playwright, and loop belongs to your stack, not to this skill. A local
+  `next build && next start`, a CI/staging container, and a per-push preview
+  deploy are equally valid rigs; the verdict comes from the build, never the
+  platform. Phase 0 maps the invariant onto your repo. Read every platform
+  name, env-var spelling, and command below as an example to translate, not a
+  requirement.
+
+## Two navigations, two loading states
+
+A route reaches the user two ways, and both must be instant:
+
+- **Initial load (hard navigation)** commits the route's prerendered static
+  shell; deferred parts stream in behind their loading skeletons (Suspense
+  fallbacks, `loading.tsx`).
+- **Client-side navigation (soft navigation)** commits the destination's
+  prefetched App Shell — the `<Link>` default under Partial Prefetching —
+  re-rendering only the segments that change.
+
+The fix patterns are identical for both; the test differs only in how the
+navigation is driven ("Driving the navigation in tests" below). The two shells
+can differ; guard the one you ship, both when both matter
+(`reference/real-app-patterns.md`).
+
+## Goal
+
+Maximizing the static shell is the optimization objective: the most meaningful
+prerendered content commits immediately, and only genuinely per-request data
+streams in afterward. The shipped test deterministically encodes **present ∧
+instant**; **non-blank** is the additional bar the workflow enforces by
+judgment (D1/D2/E), because an `instant()` pass alone is satisfied by a blank
+`fallback={null}` shell (the empty-shell failure mode,
+`reference/real-app-patterns.md`).
+
+`instant()` is a ruler, not a stopwatch: assert that the shell appears under
+the lock; do not time it. A trustworthy verdict requires a production build
+(phase A).
+
+The GREEN under the lock is the deterministic verdict; each gate keeps it
+trustworthy.
+
+## Reporting to the user
+
+This loop is meant to run unattended, so it doesn't stop to ask between steps.
+Work the navigation the user named, finish it, and stop. What matters is how you
+word and present the results, not how often you interrupt. The mechanics below —
+the rig, RED, GREEN, the gates — are your scaffolding; the user never needs to
+hear those words.
+
+- **Speak their language.** Describe the gap and the result in terms of what the
+  user sees: "navigating to the dashboard waited on the charts query before
+  anything painted; now the layout and skeletons paint instantly and the charts
+  stream in" — not RED/GREEN, the lock, or the phase letters.
+- **Show, don't tell.** When you report a route, drive the browser (or attach
+  before/after screenshots) so the user watches the shell commit immediately and
+  the data stream in, rather than reading a claim. Identical before and after
+  means the fix did nothing — roll it back.
+- **Present a run as a list of results the user can click through** — one line
+  per navigation: the route, what commits instantly, and what streams in — not a
+  transcript of the loop.
+- **Only surface a question for a genuine fork:** a fix that would change
+  behavior, a security-sensitive read, or a route that's dynamic by design (a
+  runtime-prefetch candidate, not a shell to grow). A clean instant fix is not a
+  fork — keep going. With no one to ask (an unattended run), don't block: take
+  the safe default and note the assumption — for a cache-freshness choice,
+  defer the read behind `<Suspense>` (always fresh, still instant) rather than
+  guess a `cacheLife`.
+
+## The workflow
+
+```
+- [ ] P  PREREQS      Next.js 16.3+ with cacheComponents: true; upgrade first → below
+- [ ] 0  SETUP        once per repo: discover + write instant-nav.rig.md     → rig-template.md
+- [ ] A  RIG          production build with the testing API exposed          → below
+- [ ] B  BASELINE     unlocked: the marker renders for the test user         → test-template.md
+- [ ] C  RED          locked instant(): the shell does not commit            → test-template.md
+- [ ] C-gate          VERIFY-RED: stop until the RED is trustworthy          → reference/red-test-robustness.md
+- [ ] D  FIX          push each Suspense boundary down to the data it guards → reference/patterns.md
+- [ ]      D1 reuse the route's existing loading UI; do not hand-build skeletons
+- [ ]      D2 the shell matches the real render at every breakpoint  → reference/real-app-patterns.md
+- [ ] E  PARITY       the refactor changed only whether the route is instant
+- [ ] F  DIFFERENTIAL revert only the fix → RED; re-apply → GREEN            → reference/red-test-robustness.md
+- [ ] G  REVIEW       PR checklist (below)
+```
+
+Phases B and C build the test; only the locked test from C ships.
+
+---
+
+## P. PREREQUISITES: current Next.js with Cache Components
+
+The workflow depends on framework capabilities that ship with current Next.js:
+
+- **Next.js 16.3+ with `cacheComponents: true`** in `next.config.ts`. Without
+  Cache Components there is no static shell to optimize.
+- **`@next/playwright`** on the same release line as the project's `next`; it
+  provides `instant()`. Verify with `npm ls next @next/playwright` (or the
+  project's package manager) and align them if they differ. The matching
+  testing API is in the `next` runtime, gated by the
+  `experimental.exposeTestingApiInProductionBuild` config flag (phase A).
+
+If the project does not meet these, upgrade first (`npx @next/codemod upgrade`
+automates most of it), then enable Cache Components in `next.config.ts`:
+
+```ts
+export default { cacheComponents: true }
+```
+
+Enabling the flag surfaces the blocking routes to resolve first; the
+[`next-cache-components-adoption`](https://github.com/vercel/next.js/tree/canary/skills/next-cache-components-adoption)
+skill drives that adoption. Reach for this optimizer once the app builds under
+Cache Components.
+
+This gate is deliberate: the skill targets current Next.js, and none of the
+verdicts below are meaningful on older versions.
+
+## 0. SETUP: discover this project's rig, once per repo
+
+The principles in this skill are fixed; the infrastructure they run on is
+yours. On first use in a repository, discover how the project builds, deploys,
+authenticates, and tests (inspect the repository first, and ask the user only
+what it cannot answer), then write the answers to a committed
+`instant-nav.rig.md`. Every later run reads that file instead of
+rediscovering. The six questions (BUILD / EXPOSE / RUN / TEST USER / DRIFT /
+LOOP), the file template, and filled examples (local-only, generic CI +
+container, preview deploy) are in **`rig-template.md`**.
+
+If the repo has no Playwright e2e harness yet, standing up a minimal one
+(`@next/playwright`, a config with `baseURL`, one authenticated path) is part
+of this step; the loop does not assume a pre-existing suite.
+
+## A. RIG: a production build with the testing API exposed
+
+Stand up the rig described by `instant-nav.rig.md`. Two invariants hold on
+every platform:
+
+1. **Never measure on `next dev`.** It does not prefetch, and its lock is
+   unreliable for blocking routes, so a dev `instant()` result is not a valid
+   RED or GREEN.
+2. **The measured build must expose the testing API.** Otherwise `instant()`
+   silently no-ops and the test passes vacuously (see
+   `reference/red-test-robustness.md`). The lock-engagement proof is the phase-C
+   RED itself: the unfixed target route is the known-blocking route, and its
+   RED under the lock shows the lock engages on this build (C-gate); the
+   self-validating variant in `test-template.md` is the in-band guarantee. Wire
+   `experimental.exposeTestingApiInProductionBuild` to a condition that is
+   true for every build you measure and never true in production:
+
+   ```ts
+   experimental: {
+     // Use the condition your platform provides, and record it in the rig file:
+     //   local:       an explicit opt-in, as below
+     //   generic CI:  process.env.DEPLOY_ENV === 'staging'
+     //   Vercel:      process.env.VERCEL_ENV === 'preview'
+     exposeTestingApiInProductionBuild:
+       process.env.EXPOSE_TESTING_API === '1',
+   }
+   ```
+
+The rig is any production-like build that exposes the testing API: a local
+`next build && next start`, a CI/staging container, and a preview deploy are
+all equally valid; the verdict comes from the build, not the platform. See
+`rig-template.md` for filled examples.
+
+For any deployed or remote build, poll the rig's LIVENESS probe to confirm the
+artifact contains `HEAD` before trusting a verdict (a stale deploy reads as a
+false RED or GREEN); a local `next build && next start` needs none. The probe
+mechanism is in `rig-template.md` (question 6).
+
+## B. BASELINE (unlocked): development scaffold, do not ship
+
+Drive the real navigation with no `instant()` lock and assert that the
+destination's `SHELL_MARKER` renders **as the test user**: the account the
+e2e suite authenticates as (in CI, the CI account; locally, your e2e login
+fixture), with its flags, plan, role, and data. This establishes that the
+marker is real and reachable: not flag-gated, not redirected away, not a
+guessed selector. The suite runs as the test account, not the author's session;
+that environment drift (the rig DRIFT list) is a common source of
+untrustworthy REDs. Scaffold and run command: **`test-template.md`**.
+**Delete this baseline before the PR.**
+
+## C. RED (locked) + the VERIFY-RED gate
+
+Wrap the same navigation in `instant()`; assert the shell commits under the
+lock. A RED here is the gap. **This is the test that ships**
+(`test-template.md`).
+
+Prefer the self-validating variant when the route has deferred content. If the
+route cannot build while blocked, or a cookie/session read stays GREEN, use the
+RED recipes in `reference/red-test-robustness.md`.
+
+> **C-gate: do not start optimizing until the RED is verified trustworthy.** A
+> RED that is red for the wrong reason sends you optimizing a route that was
+> never broken.
+
+The question that settles it: **does `SHELL_MARKER` render without the lock,
+as the test user?** Answer it by re-running phase B as the test user, not by
+adding assertions to the shipped test. The two-branch resolution (No → marker
+or environment bug; Yes → genuine gap, proceed to D), the full taxonomy of
+untrustworthy REDs, the checklist, and worked cases are in
+**`reference/red-test-robustness.md`**. Read it now.
+
+---
+
+## D. FIX: push each boundary down to the data it guards
+
+**The anti-pattern: one coarse boundary.** A single `<Suspense>` high in the
+tree with a page-level fallback has three costs:
+
+- The layout UI stays out of the static shell: only a throwaway copy of it is
+  prerendered.
+- The entire subtree is replaced when the boundary resolves, which discards
+  client state and shifts layout.
+- The hand-built fallback drifts out of sync as the UI changes, because it
+  duplicates structure that also exists in the resolved tree.
+
+**The fix: hoist the static, push the Suspense down.** Render the layout UI
+once, synchronously, in the shell, and wrap each await in a boundary scoped to
+the single read it guards. Only that leaf streams; the stable ancestors are
+reused as-is.
+
+**Rule:** if an element renders in both the fallback and the resolved tree,
+hoist it above the boundary.
+
+### The most common blocker: a top-level `await` in a layout on a fallback route
+
+```
+app/[locale]/(app)/[tenant]/dashboard/...
+       │ generateStaticParams ✅   │ no generateStaticParams → fallback route
+```
+
+When any dynamic segment in the route lacks `generateStaticParams`, the route
+is a fallback route, and **all** params defer to request time, including the
+enumerated ones. A top-level `await` in a layout (`await params`, a
+request-time session read, an auth gate) then blocks the whole subtree out of
+the static shell, even when it reads a statically known param. Minimal shape: a
+dynamic-segment route with one segment lacking `generateStaticParams`, plus a
+top-level `await` in the layout above it.
+
+### The fix: defer the gate, render children
+
+Render `children` unconditionally; move the top-level `await` into a
+`<Suspense fallback={null}>`-wrapped child. Mechanism and before→after:
+`reference/real-app-patterns.md`, "Deferring an auth gate".
+
+**Fix the page below the shell too, not only the layout.** A page-level
+top-level `await` (commonly `await params`) blocks the same way the layout's
+does, so make the page sync and push its dynamic reads into a
+`<Suspense>`-wrapped leaf as well. `fallback={null}` is correct only when a gate renders nothing on
+success; for data, the fallback must be a real loading skeleton (see D1).
+
+Every other blocker shape — `cookies()`/`headers()`, uncached fetch or database
+reads, `searchParams`, metadata, viewport, non-deterministic values (`Date.now()`,
+`Math.random()`, `crypto.randomUUID()`) — surfaces its own insight when you hit
+it: the build prints a `https://nextjs.org/docs/messages/<slug>` link. The
+default build output is often abbreviated and may carry no usable stack trace;
+add `--debug-prerender` for the full failing frame and to report every blocker
+past the first. Scope the build to the route you're on with
+`next build --debug-build-paths "app/<route>/**"` rather than rebuilding the app.
+Open that page and apply its recipe; don't improvise from the inline message.
+
+The before→after recipe for each shape is in `reference/patterns.md`, which maps it to the insight
+that explains it.
+
+A few things those per-error pages don't stress for the instant-navigation goal:
+
+- **A boundary in the root layout isn't enough for client navigations.** It
+  passes a page-load check but leaves sibling client navigations blocking; put
+  the boundary below the lowest layout the source and destination routes share.
+- **Keep the LCP element** (usually the main heading) out of any boundary, so it
+  paints in the shell instead of waiting on a stream.
+- **A green check isn't always instant.** `export const instant = false` opts
+  the segment out of validation while the navigation still blocks, and a
+  `<Suspense>` above the document `<body>` prerenders an empty shell — neither
+  makes the route instant.
+
+### D1: reuse the route's existing loading UI; do not hand-build skeletons
+
+Before writing any skeleton, search the repository for the loading UI that
+already exists for this route, in order:
+
+1. the route's `loading.tsx`;
+2. an exported `*Skeleton` colocated with the component;
+3. the fallback already inside the component's own `<Suspense>`.
+
+The **divergence point** is the lowest layout shared by the source and
+destination routes: a soft navigation re-renders only the segments below it,
+while an initial load re-runs every layout from the root. (Also called the
+shared boundary.) A `loading.tsx` above the divergence point fills only
+the initial-load shell; it sits above the soft-nav re-render scope. A
+`loading.tsx` at the destination segment is itself the in-tree boundary for a
+soft navigation into that segment and serves both. Reuse whichever boundary
+actually covers the navigation you are shipping; below the divergence point,
+`loading.tsx` and colocated skeletons are interchangeable for that purpose.
+
+If a component has no skeleton, extract its loading markup into a colocated
+skeleton beside it. Do not author a fresh skeleton that mirrors the page
+layout: it duplicates structure, drifts as the page changes, and pulls the
+design back toward a single coarse boundary. Reusing the component's own
+skeleton also keeps the prefetched shell consistent with the loaded UI.
+
+See: [Streaming](https://nextjs.org/docs/app/guides/streaming#push-dynamic-access-down)
+and [loading states](https://nextjs.org/docs/app/guides/instant-navigation#iterate-on-loading-states).
+
+Exception: if the deferred component renders `null` for some users (for
+example, a flag-gated control), `fallback={null}` is correct, since a skeleton
+would flash and then collapse.
+
+### D2: the shell must match the real render at every breakpoint
+
+A skeleton frozen to one breakpoint misaligns on the others. Fix it the same
+way: one responsive component renders both the live UI and the shell (D1
+skeleton in its data slots), so the breakpoint switch happens once. Verify by
+re-asserting the shell marker at two widths
+(`await page.setViewportSize({ width: 1280, height: 800 })`, then
+`{ width: 390, height: 844 }`), or by adding a mobile Playwright project, so
+this gate is as machine-checkable as the others. Detail:
+`reference/real-app-patterns.md`.
+
+> **D-gate: phase D is complete when the locked test from phase C passes GREEN
+> under the lock on the production-build rig**, not when the code compiles. That
+> GREEN is the deterministic stop for the fix loop; proceed to E.
+
+**When URL data can't be pushed down** (for example, the whole page depends on
+`params`, `searchParams`, or the full URL), there may be no meaningful static
+shell to grow. Don't force one. Runtime prefetching can make the soft
+navigation instant, but it is outside this optimizer loop: it requires Partial
+Prefetching, a `<Link prefetch={true}>`, and cached URL-dependent content. See
+[Runtime Prefetching](https://nextjs.org/docs/app/guides/runtime-prefetching)
+and pattern 10 in `reference/patterns.md` for the requirements, cost trade-offs,
+manual prefetch caveat, and `instant()` test gotchas.
+
+## E. PARITY: the refactor changed only whether the route is instant
+
+The push-down is a mechanical transform, not a redesign. Afterward the route
+must render the same tree, data, ordering, empty and error states, redirects,
+and interactions as before; the only observable difference is that the shell
+now commits instantly. Verify:
+
+- **Same render output.** The moved `await`s compute and return the same
+  values; after the stream, the route shows the same content as the base
+  branch for the test user.
+- **Side effects still fire.** A deferred `redirect()` or `notFound()` still
+  happens, at request time rather than during prerender. Confirm an
+  unauthorized user is still redirected and a missing record still returns 404.
+- **Both viewports reach the real UI** after the stream (D2).
+- **Client state survives.** Because the layout UI is hoisted into the stable
+  shell rather than swapped on resolve, open menus, scroll position, focus,
+  and input state persist across the stream.
+- **Pre-existing failures stay separate.** If the route errors after the
+  change, reproduce it on the base branch. The same failure there is an
+  environment or data problem, not an optimizer regression.
+
+If anything other than whether the route is instant changed, reduce the refactor.
+
+## F. DIFFERENTIAL
+
+Revert only the fix → RED; re-apply → GREEN; link both runs
+(`reference/red-test-robustness.md`). On a deployed rig, confirm each run is live
+(LIVENESS, phase A) before trusting its color.
+
+## G. REVIEW (PR checklist)
+
+A green final state means nothing if the RED was never trustworthy. The
+test-trustworthiness items are the robustness checklist
+(`reference/red-test-robustness.md`); confirm them, then require these
+PR-specific items:
+
+- [ ] **Differential shown**: RED without the fix, GREEN with it, runs linked.
+- [ ] **Parity confirmed (E)**: same content, redirects, and state.
+- [ ] **Existing loading UI reused (D1)**: no new page-mirroring skeleton.
+- [ ] **Shell matches the real render at desktop and mobile widths (D2)**.
+- [ ] **Baseline removed**: only the locked test from C remains.
+
+**Stop condition for the whole workflow:** the locked test from C is GREEN on
+the rig, the differential (F) holds, and every item above is checked. Until all
+three hold, you are not done.
+
+## Driving the navigation in tests
+
+- **Soft navigation** → drive a real `<Link>` click. **Initial load** → use
+  `page.goto()` inside `instant()` with the `baseURL` option. Do not substitute
+  `goto` for a soft-nav verdict; the two shells can differ
+  (`test-template.md`, `reference/real-app-patterns.md`).
+- With parallel routes, only the slots that change re-render on a soft
+  navigation; client-rendered navigation UI does not re-render at all. Do not
+  chase a slot the navigation never touches
+  (`reference/real-app-patterns.md`).
+
+## Files
+
+- `rig-template.md`: phase 0, the six-question rig discovery, the
+  `instant-nav.rig.md` template, and filled examples (local-only, generic CI,
+  preview deploy).
+- `test-template.md`: the shipped `instant()` specs for both navigation
+  types (phase C), and the delete-before-PR baseline scaffold (phase B).
+- `reference/red-test-robustness.md`: the C-gate and phase F. The taxonomy of
+  untrustworthy REDs, the checklist, the differential recipe, the vacuous-pass
+  failure mode, and worked cases.
+- `reference/real-app-patterns.md`: parallel routes, deferring an auth gate,
+  initial-load vs soft-navigation shells, the empty-shell failure mode, the
+  responsive-skeleton mismatch, edge cases.
+
+## After optimization
+
+Once the target routes are instant, check whether the app has already adopted
+Partial Prefetching (`partialPrefetching: true`, or the relevant destination
+still uses `prefetch = 'partial'` during an incremental rollout).
+
+Make that check mechanically:
+
+```bash
+rg -n "partialPrefetching|prefetch\s*=\s*['\"]partial['\"]" --glob 'next.config.*' --glob 'app/**' --glob 'src/app/**'
+```
+
+If `partialPrefetching: true` is in config, the app is globally adopted. If only
+`prefetch = 'partial'` matches, treat those destination segments as adopted
+during an incremental rollout and keep checking any other target routes.
+
+- **Already adopted:** for any URL-data route that stopped at the limitation
+  above, consider a targeted `<Link prefetch={true}>` on the links where having
+  that URL-specific content ready before the click is worth the per-link server
+  work. Keep the default link behavior everywhere else so the shared App Shell
+  remains the low-cost baseline.
+- **Not adopted yet:** recommend
+  [`next-partial-prefetching-adoption`](https://github.com/vercel/next.js/tree/canary/skills/next-partial-prefetching-adoption).
+  That skill moves the app onto the better prefetching model: shared App Shell
+  prefetches by default, fewer duplicated full-prefetch requests for visible
+  links, a link audit for existing `<Link prefetch={true}>` usage, and optional
+  per-link runtime prefetching only where URL-specific content is worth the
+  extra server work.

--- a/.agents/skills/next-cache-components-optimizer/reference/patterns.md
+++ b/.agents/skills/next-cache-components-optimizer/reference/patterns.md
@@ -1,0 +1,357 @@
+# Refactor patterns — push dynamic down into the shell
+
+Each pattern is **before → after**: keep as much as possible in the prerendered shell, and wrap only genuinely per-request work in a tight `<Suspense>` (or hoist it into `use cache`). Production shapes — parallel-route slots, deferring an auth gate, client slot-routers — are in `real-app-patterns.md`.
+
+---
+
+## 1. Awaiting at the top → move the await into a Suspense child
+
+The most common blocking shape. Awaiting request-time data at the top of a page/layout makes **everything below it** dynamic.
+
+```tsx
+// ❌ before — top-level await of a non-static param + uncached data
+export default async function Page(props: PageProps<'/store/[slug]'>) {
+  const { slug } = await props.params
+  const product = await db.products.findBySlug(slug)
+  return (
+    <article>
+      <h1>{product.name}</h1>
+    </article>
+  )
+}
+```
+
+```tsx
+// ✅ after — pass the params promise down; await inside a Suspense-wrapped child
+import { Suspense } from 'react'
+
+export default function Page(props: PageProps<'/store/[slug]'>) {
+  return (
+    <Suspense fallback={<p>Loading product…</p>}>
+      <Product params={props.params} />
+    </Suspense>
+  )
+}
+
+async function Product({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const product = await db.products.findBySlug(slug)
+  return (
+    <article>
+      <h1>{product.name}</h1>
+    </article>
+  )
+}
+```
+
+Inline variant when you don't want a separate component — unwrap the promise without awaiting at the top:
+
+```tsx
+export default function Page(props: PageProps<'/store/[category]'>) {
+  return (
+    <Suspense fallback={<Grid.Skeleton />}>
+      {props.params.then(({ category }) => (
+        <ProductGrid category={category} />
+      ))}
+    </Suspense>
+  )
+}
+```
+
+**Insight:** [runtime data during prerendering](https://nextjs.org/docs/messages/blocking-prerender-runtime).
+
+---
+
+## 2. `cookies()` / `headers()` in a layout → start, don't await; pass down
+
+A layout that awaits request data blocks the layout **and every page under it**.
+
+```tsx
+// ❌ before — whole layout (and all children) becomes dynamic
+export default async function Layout({ children }) {
+  const cookieStore = await cookies()
+  const theme = cookieStore.get('theme')?.value
+  return <body data-theme={theme}>{children}</body>
+}
+```
+
+```tsx
+// ✅ after — start the read without awaiting, pass the promise to a Suspense child
+import { Suspense } from 'react'
+import { cookies } from 'next/headers'
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  const cookieStore = cookies() // not awaited → does not block the shell
+  return (
+    <body>
+      <nav>
+        <Suspense fallback={<UserMenu.Skeleton />}>
+          <UserMenu cookiePromise={cookieStore} />
+        </Suspense>
+      </nav>
+      {children}
+    </body>
+  )
+}
+
+async function UserMenu({
+  cookiePromise,
+}: {
+  cookiePromise: ReturnType<typeof cookies>
+}) {
+  const theme = (await cookiePromise).get('theme')?.value
+  return <div data-theme={theme}>…</div>
+}
+```
+
+`{children}` and `<nav>` stay in the shell; only `<UserMenu>` streams.
+
+**Insight:** [runtime data during prerendering](https://nextjs.org/docs/messages/blocking-prerender-runtime).
+
+---
+
+## 3. Uncached fetch / DB read → choose `use cache` _or_ `<Suspense>`
+
+Decide per data source. Same-for-everyone & rarely-changing → cache it (it joins the shell). Per-request & must-be-fresh → leave it uncached behind a boundary.
+
+```tsx
+// ❌ before — both block the shell
+const product = await db.products.findBySlug(slug) // rarely changes
+const inventory = await db.inventory.findBySlug(slug) // must be fresh
+```
+
+```tsx
+// ✅ after — cache the stable one (shell), defer the fresh one (streams)
+async function getProduct(slug: string) {
+  'use cache' // → resolved at prerender, lands in the shell
+  return db.products.findBySlug(slug)
+}
+
+;<Suspense fallback={<p>Checking availability…</p>}>
+  <Inventory params={params} /> {/* uncached read stays here, streams in */}
+</Suspense>
+```
+
+> A bare `'use cache'` applies the `default` `cacheLife` profile. Choose freshness explicitly with `cacheLife('<profile>')` (`default` / `seconds` / `minutes` / `hours` / `days` / `weeks` / `max`) rather than shipping the default lifetime by omission.
+>
+> Serverless note: `use cache` is in-memory and does not persist across instances — use [`use cache: remote`](https://nextjs.org/docs/app/api-reference/directives/use-cache-remote) for a durable shell.
+
+**Insight:** [uncached data during prerendering](https://nextjs.org/docs/messages/blocking-prerender-dynamic).
+
+---
+
+## 4. Dynamic params → `generateStaticParams` (shell) or `<Suspense>` (stream)
+
+If the set of params is enumerable, prerender them so `await params` resolves into the shell. Otherwise treat params as request-time and wrap consumers in `<Suspense>`.
+
+```tsx
+// ✅ option A — enumerate → params resolve into the shell, no Suspense needed for params
+export function generateStaticParams() {
+  return [{ slug: 'shoes' }, { slug: 'hats' }]
+}
+export default async function Page({ params }: PageProps<'/store/[slug]'>) {
+  const { slug } = await params // known at build → shell-safe
+  // ...
+}
+```
+
+```tsx
+// ✅ option B — not enumerable → params is request-time; await it inside a boundary (pattern #1)
+```
+
+Root params (the dynamic segments the root layout sits inside, e.g. `app/[lang]/layout.tsx`) are readable from any Server Component via `next/root-params` without prop-drilling — but under Cache Components they must still be enumerated by `generateStaticParams` (at least one value per root param) to land in the shell, the same as any other dynamic param.
+
+**Insight:** [runtime data during prerendering](https://nextjs.org/docs/messages/blocking-prerender-runtime).
+
+---
+
+## 5. `searchParams` → always behind `<Suspense>` (on page load)
+
+Search params are never known at build, so awaiting them (or `useSearchParams()`) suspends on a page load. Keep the rest of the page in the shell by isolating the consumer.
+
+```tsx
+// ✅ static content stays in the shell; the search-dependent part streams
+export default function Page(props: PageProps<'/search'>) {
+  return (
+    <>
+      <h1>Search</h1> {/* shell */}
+      <Suspense fallback={<Results.Skeleton />}>
+        <Results searchParams={props.searchParams} />
+      </Suspense>
+    </>
+  )
+}
+async function Results({
+  searchParams,
+}: {
+  searchParams: Promise<{ q?: string }>
+}) {
+  const { q } = await searchParams
+  return <ResultList query={q} />
+}
+```
+
+On a **client navigation** the router already has the URL, so a `useSearchParams()` consumer resolves synchronously and can appear in the prefetched shell — but you still need the boundary for the page-load path.
+
+**Insight:** [runtime data during prerendering](https://nextjs.org/docs/messages/blocking-prerender-runtime) (or, via `useSearchParams` in a Client Component, [URL data in a Client Component](https://nextjs.org/docs/messages/blocking-prerender-client-hook)).
+
+---
+
+## 6. Non-deterministic values → `connection()` + `<Suspense>`, or cache
+
+`Math.random()`, `Date.now()`, `crypto.randomUUID()` produce different output each run, so Cache Components makes you choose: per-request (defer) or fixed (cache).
+
+```tsx
+// ✅ per-request value: gate on connection() and wrap in Suspense
+import { connection } from 'next/server'
+async function RequestId() {
+  await connection()
+  return <span>{crypto.randomUUID()}</span>
+}
+// <Suspense fallback={null}><RequestId /></Suspense>
+```
+
+```tsx
+// ✅ same value for everyone: cache it so it joins the shell
+async function buildId() {
+  'use cache'
+  return Date.now()
+}
+```
+
+**Insight:** [`Date.now()`](https://nextjs.org/docs/messages/blocking-prerender-current-time), [`Math.random()`](https://nextjs.org/docs/messages/blocking-prerender-random), or [`crypto`](https://nextjs.org/docs/messages/blocking-prerender-crypto) while prerendering.
+
+---
+
+## 7. Dynamic `generateMetadata` → static export, `use cache`, or a dynamic-marker for runtime data
+
+```tsx
+// ❌ before — reading request data blocks the route's metadata
+export async function generateMetadata() {
+  const c = await cookies()
+  return { title: c.get('title')?.value }
+}
+```
+
+```tsx
+// ✅ option A — static
+export const metadata = { title: 'Store' }
+
+// ✅ option B — cache the metadata (depends on external data, not runtime data)
+export async function generateMetadata() {
+  'use cache'
+  return { title: await getTitle() }
+}
+```
+
+```tsx
+// ✅ option C — metadata genuinely needs runtime data (cookies/headers):
+// keep generateMetadata dynamic, and add a dynamic-marker component to the
+// page so the rest of the page still prerenders into the shell.
+import { Suspense } from 'react'
+import { connection } from 'next/server'
+import { cookies } from 'next/headers'
+
+export async function generateMetadata() {
+  const token = (await cookies()).get('token')?.value
+  return { title: token ? 'Personalized' : 'Store' }
+}
+
+async function DynamicMarker() {
+  await connection() // signals intentional dynamic content
+  return null
+}
+
+export default function Page() {
+  return (
+    <>
+      <article>{/* static content — stays in the shell */}</article>
+      <Suspense>
+        <DynamicMarker />
+      </Suspense>
+    </>
+  )
+}
+```
+
+`generateViewport` is the same, except dynamic viewport blocks the **whole page**. Genuine instant fixes: a static `viewport` export, or `use cache`. The other two are dynamic-acceptance opt-outs, not instant fixes — do not treat them as a way to reach GREEN: `export const instant = false` opts the segment out of validation while the navigation still blocks, and a `<Suspense>` above the document `<body>` makes the whole route dynamic.
+
+**Insight:** [runtime data in `generateMetadata()`](https://nextjs.org/docs/messages/blocking-prerender-metadata-runtime).
+
+---
+
+## 8. Keep the LCP element in the shell
+
+Don't bury the main heading (the LCP element) inside a boundary — it can't paint until the boundary resolves.
+
+```tsx
+// ✅ LCP outside the boundary → paints in the shell
+<h1>{product.name}</h1>                 {/* shell (cache the name if needed) */}
+<Suspense fallback={<Reviews.Skeleton />}>
+  <Reviews productId={id} />            {/* streams */}
+</Suspense>
+```
+
+---
+
+## 9. Granularity below shared layouts (client-nav correctness)
+
+A single boundary in the **root** layout passes a page-load check but leaves sibling client navigations blocking. Put a boundary **below the shared layout**.
+
+```tsx
+// app/store/layout.tsx — boundary below the /store shared layout covers
+//   client navs like /store/shoes → /store/hats (the root boundary does not)
+export default function StoreLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <section>
+      <StoreNav /> {/* shell */}
+      <Suspense fallback={<Page.Skeleton />}>{children}</Suspense>
+    </section>
+  )
+}
+```
+
+Prefer per-component boundaries inside the page (patterns #1–#5) over one big layout boundary — they keep more real content in the shell and stream independently.
+
+**Insight:** the read's own insight surfaces on the client navigation when the boundary is too high — see [where to place the boundary](https://nextjs.org/docs/messages/blocking-prerender-dynamic#choosing-where-to-place-the-boundary).
+
+## 10. URL data that can't move
+
+Patterns 1–9 grow a **static shell** by moving dynamic reads behind boundaries. Session data from `cookies()` and `headers()` is handled by the earlier patterns. URL data is different: `params`, `searchParams`, and the full URL belong to one link, while the App Shell is shared by every link to the route.
+
+If the whole route depends on URL data, pushing the read lower may leave no meaningful shared shell to commit. That is the optimizer's stop point, not another shell refactor. Return to `SKILL.md` after the optimization loop for the optional runtime-prefetch follow-up.
+
+Runtime prefetching is the only way for this soft navigation to commit the
+URL-specific content before the click. It has **three requirements**:
+
+```tsx
+// 1. The destination has adopted Partial Prefetching, either app-wide with
+//    partialPrefetching: true or route-by-route with prefetch = 'partial'.
+
+// 2. The navigation asks for a full prefetch — normally <Link prefetch={true}>.
+//    A default/auto prefetch only warms the static shell.
+<Link href={href} prefetch={true}>
+  …
+</Link>
+
+// 3. The URL-dependent content is behind `use cache`, keyed by the resolved
+//    params/searchParams/full URL value.
+```
+
+Under `instant()` the runtime entry is what commits, so the real content, not a skeleton, shows under the lock.
+
+Gotchas (each cost real debugging time):
+
+- **The full prefetch is mandatory.** With App Shells enabled an auto/PPR prefetch bails before the runtime spawn (`subtreeHasSpeculativePrefetch`); use `<Link prefetch={true}>` for normal links, or keep an existing manual full-prefetch abstraction if the app already owns one. If the route is still RED after caching the URL-dependent content, the navigation may still be doing an auto prefetch.
+- **Partial Prefetching must be adopted for the destination.** Runtime prefetching rides on the Partial Prefetching path. If the route is still RED after caching the URL-dependent content, check whether the link is still doing an auto prefetch or whether the destination never adopted Partial Prefetching.
+- **Prefetch the canonical URL.** A link whose href 307-redirects (a `/foo` that canonicalizes to `/`) can't be prefetched — the prefetch receives the redirect, not the tree. Point the link and the prefetch at the final URL.
+- **Don't blanket the full prefetch.** It fetches _all_ the target's dynamic data; enabling it for every visible link is wasteful. Scope `prefetch={true}` to the runtime-prefetch targets only, using the [runtime prefetching trade-offs](https://nextjs.org/docs/app/guides/runtime-prefetching#per-link-prefetching-trade-offs) and [hover-triggered prefetch](https://nextjs.org/docs/app/guides/prefetching#hover-triggered-prefetch) when many links are visible.
+- **Marker must be a committed node, not RSC bytes.** The content is often a client component, so its text isn't in the prefetch response — assert a `data-testid` that renders when the client subtree commits, not a substring of the stream.
+
+Prefer a static shell (patterns 1–9) whenever the URL-data read can move: it's cheaper than a runtime prefetch and also covers hard load. Runtime prefetching is only for URL-data reads that genuinely can't move, or routes whose useful content is all URL-specific.
+
+**Insight:** [dynamic data during prefetching](https://nextjs.org/docs/messages/instant-link-prefetch-partial).

--- a/.agents/skills/next-cache-components-optimizer/reference/real-app-patterns.md
+++ b/.agents/skills/next-cache-components-optimizer/reference/real-app-patterns.md
@@ -1,0 +1,88 @@
+# Real-app patterns
+
+The rest of this skill models a single linear `layout → page` tree. Production App Router routes add **parallel routes, shared layout UI, and auth gates**, which is where most of the real static-shell work happens. These patterns bridge that gap. Read the skill's `SKILL.md` first.
+
+## Parallel routes: each slot is its own boundary
+
+Instant validation treats every parallel-route slot below the shared layout as an **independent** navigation boundary. Consequences:
+
+- **Each `@slot` needs its own `<Suspense>`** around its dynamic reads; a boundary in one slot does not cover another.
+- **An uncovered dynamic read in any slot blocks the whole navigation.** A perfect `@content` does not help if `@sidebar` awaits a session at the top.
+- **A slot that renders `null` (e.g. `default.tsx`) is shell-safe**: it is static and performs no reads. Slots that do not re-render for this navigation cost nothing.
+
+```
+[tenant]/layout.tsx         (shared: already mounted on a soft navigation; not re-rendered)
+  ├ @content  → settings/layout → billing/page     ← guard each slot's dynamic reads…
+  ├ @sidebar  → side nav                            ← …here too (independent boundary)
+  └ @header   → default.tsx → null                  ← free
+```
+
+## Client-rendered slot routing is not part of the soft-navigation re-render
+
+A common pattern: a stable shared layout renders `@header`/`@sidebar` through a **client** component that swaps slot content based on `usePathname()`. On a soft navigation, Next.js only re-renders the **server** segments that changed below the shared layout; a client-component subtree is not part of that re-render. So that navigation UI neither blocks the navigation nor needs a server `<Suspense>` for it; only the server segments that actually change (e.g. `@content`) matter. It does participate in an initial load (see the caveat below).
+
+## "Instant" is not "useful shell": the empty-shell failure mode
+
+Validation checks that a dynamic read is **guarded by a boundary**, not that the fallback is non-empty. A `<Suspense>` with no `fallback` (or `fallback={null}`) passes validation and commits instantly, but renders a **blank** shell. If a layout and its page both `await getSession()` (your auth library's request-time read) at the top under one empty-fallback boundary, the whole frame collapses to nothing while the user waits. "Validates as instant" and "good loading experience" are different goals.
+
+> Give every boundary a real loading skeleton, and place it low so the most real content stays in the shell. A `fallback={null}` directly above `<body>` is a deliberate empty-shell opt-out; an empty fallback lower in the tree is almost always a bug.
+
+## The responsive-skeleton mismatch: the shell must match every breakpoint
+
+A loading skeleton that misaligns with the loaded UI is its own bug, and it usually appears on mobile. A hand-built skeleton encodes one layout; the real component is responsive and changes shape at breakpoints, so a desktop-shaped skeleton no longer lines up once the viewport is small.
+
+A concrete shape: a list-detail view renders a list or tree in a side panel on desktop, but collapses that panel into a single dropdown or drawer on mobile (with its own loading state). A row skeleton built for the desktop panel has nothing to align with on mobile.
+
+The fix is the same push-down as everywhere else: **share the real responsive layout between the live render and the shell render.** One responsive component renders both (its data slots show the reused `*Skeleton` in the shell and real data after the stream), so the breakpoint switch happens once, for both renders, and there is no second desktop-only skeleton to drift.
+
+(Same hoist rule, responsive layout included.) Verify the shell at both desktop and mobile widths against the real render at the same width.
+
+## Deferring an auth gate / top-level `await` in a layout
+
+A top-level `await` in a layout blocks everything below it (the most common blocker; see [Runtime data during prerendering](https://nextjs.org/docs/messages/blocking-prerender-runtime)). Auth gates are the most common real instance:
+
+```tsx
+// ❌ Before: the await + redirect at the top blocks the whole settings frame
+export default async function SettingsLayout({ children }) {
+  const session = await getSession() // your auth library's request-time read; suspends during prerender → frame can't build
+  if (!session?.user) redirect(getLoginUrl())
+  return <Shell>{children}</Shell>
+}
+```
+
+```tsx
+// ✅ After: render children unconditionally; move the gate into a Suspense child
+import { Suspense } from 'react'
+
+export default function SettingsLayout({ children }) {
+  return (
+    <Shell>
+      <Suspense fallback={null}>
+        <AuthGate />
+      </Suspense>
+      {children}
+    </Shell>
+  )
+}
+
+async function AuthGate() {
+  const session = await getSession() // the session read suspends during prerender…
+  if (!session?.user) redirect(getLoginUrl()) // …so redirect() never runs at build time
+  return null
+}
+```
+
+The shell prerenders as if authorized (the session read suspends before `redirect()` is reached, so the redirect only happens at request time), and `{children}` is now in the shell instead of behind the gate. (`fallback={null}` is correct here: `AuthGate` renders nothing on success.)
+
+## Initial-load shell vs soft-navigation shell
+
+The `test-template.md` specs drive a `<Link>` click for soft navigations and `page.goto()` for initial loads. The two shells can differ for the same route:
+
+> **The initial-load shell can show less than the soft-navigation shell when a layout above the shared boundary awaits un-enumerated `params`/`searchParams`.** An initial load re-runs every layout from the root; if a parent layout does `await props.params` and that segment has no `generateStaticParams`, the param suspends on the initial load and its whole subtree drops out of the shell. A soft navigation does not re-render that parent and already has the params. Symptom: an element present after a `<Link>` click is missing after `goto`.
+
+To assert the soft-navigation shell, drive a real `<Link>` click (through menus if necessary). Use `page.goto()` inside `instant()` to assert the initial-load shell, or when no parent above the shared boundary awaits un-enumerated params, in which case the two coincide.
+
+## Edge cases
+
+- **A `React.cache` (or custom memoization) wrapper around `cookies()`/`headers()` still suspends.** Memoizing the call does not make it shell-safe: the underlying request read still returns a pending promise during prerender. Only the **`use cache`** directive, keyed on static or param inputs, puts data in the shell.
+- **Playwright cannot see a `display: contents` or fragment fallback.** Such a fallback reads as hidden, so `instant()` assertions cannot `toBeVisible()` it. Give fallbacks a real wrapper element with a `data-testid`.

--- a/.agents/skills/next-cache-components-optimizer/reference/red-test-robustness.md
+++ b/.agents/skills/next-cache-components-optimizer/reference/red-test-robustness.md
@@ -1,0 +1,156 @@
+# RED-test robustness: verify the RED before optimizing
+
+The C-gate of the workflow. A RED that is red for the wrong reason sends you optimizing a route that
+was never broken: the route becomes instant, the test stays red (or the code is contorted to
+satisfy a broken assertion), and the effort lands on the wrong problem. The prevention is cheap:
+spend a few minutes verifying the RED is trustworthy first.
+
+## The deciding question
+
+> **Does the marker render WITHOUT the lock, as the test user?**
+
+- **No**: the test is red because the marker or page is not there for that user or environment. A
+  marker bug, not an instant-navigation bug. Fix the marker. (This is the most common case.)
+- **Yes**: the marker exists and is reachable; a red under the lock is a genuine "not instant".
+  Optimize the route.
+
+Everything below serves answering that question honestly.
+
+## When the blocked route will not build
+
+With Cache Components, a top-level blocking read can fail the build before the
+test can produce a RED. Add `export const instant = false` to the target route
+as part of the temporary RED scaffold. It lets the known blocker build without
+making the navigation instant. Remove the opt-out with the fix, and include it
+when reverting the fix for the differential.
+
+## Cookie and session reads are not lock probes
+
+Do not manufacture a RED with `cookies()` or a session read alone. The testing
+lock restricts the navigation to its shell; it does not make request cookies
+unavailable. Use the route's real blocking uncached data, and prefer the
+self-validating test variant when deferred content exists.
+
+## The robustness checklist (all must hold)
+
+1. **Red on baseline**: fails on the unfixed route.
+2. **Right reason**: without the lock, the marker is visible on the production-build rig (never
+   `next dev`), running as the test user, not only in the author's own logged-in session.
+3. **Differential**: reverting only the fix → RED; re-applying → GREEN; nothing else moves it.
+4. **Non-gameable marker**: a sync element of the static shell, never streamed data.
+5. **Deterministic on a production build**: stable across N runs; never `next dev`.
+6. **Discriminating both ways**: present under the lock on an instant route, absent under the
+   lock on a blocking one.
+7. **Renders for the test user**: under that user's flags, plan, role, and data.
+8. **Conditional redirects accounted for**: assert at the route's real destination for that user.
+9. **Real selector**: a `data-testid` on a known static-shell node, not a guessed `role`/`name`.
+10. **Visible marker**: not `display:none`, off-screen, or inside a hover overlay; for lists,
+    target `.filter({ visible: true }).first()`.
+11. **Fresh build under test**: the deployment being measured contains the latest commit, not a
+    build URL still serving the previous deploy.
+
+## Taxonomy: red for the wrong reason
+
+Any of these makes a RED untrustworthy. None of them is "the navigation isn't instant."
+
+| Wrong reason                 | How it occurs                                                                              | How to rule it out                                                                                |
+| ---------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| **Selector matches nothing** | a guessed `getByRole('button', { name: 'Folder' })`                                        | grep the component for the real accessible name; add a `data-testid`                              |
+| **Conditional redirect**     | the route `redirect()`s for the test user (flag/role), so the marker page is never reached | check the page's top-level branches; assert at the real destination, or pin the flag              |
+| **Flag / plan / role gate**  | the author has the flag or plan; the test user does not                                    | run the unlocked baseline as the test user; pin flags via the project's override mechanism        |
+| **Empty state**              | the marker only exists when data does; the CI account is empty                             | pick a marker present in the empty state (a layout element such as the page header), or seed data |
+| **Timeout / flake**          | a slow API or transient infrastructure error                                               | re-run; separate infrastructure flake from a real signal                                          |
+| **Streamed marker**          | the marker is behind `<Suspense>`, so it is never in the shell                             | choose a sync shell element; verify it sits outside every `<Suspense>`                            |
+| **Auth redirect**            | unauthenticated → `/login`                                                                 | confirm login succeeded before the navigation                                                     |
+| **Stale deployment**         | the test ran against the previous build (the URL under test still serves the prior deploy) | poll the deployment for a marker from the latest commit before trusting any verdict               |
+| **Hidden / off-screen**      | the testid is on a hover-overlay or off-screen list item                                   | put the marker on an always-visible node; `.filter({ visible: true }).first()` for lists          |
+
+## Worked cases
+
+These are illustrative failures from real optimization runs; each was red for a wrong reason, and
+none was an instant-navigation problem. One app's drift surface might be dominated by feature flags and
+plans; another's by auth state, an empty database, or locale. The taxonomy lists every wrong
+reason; the rig file's DRIFT list says which rows apply to your app.
+
+- **Guessed selector + empty state**: the marker was a button picked by a guessed accessible name
+  that no element actually had, on a list page whose CI account had no rows. → checks 7, 9. Fix: a
+  `data-testid` on a real static-shell node.
+- **Hidden marker**: the testid sat first on a `hidden sm:block` hover-overlay link, then on an
+  off-screen carousel card; Playwright resolved the element but reported it hidden. → check 10.
+  Fix: an always-visible node; for lists, `.filter({ visible: true }).first()`.
+
+## Differential check (capture in the PR)
+
+The strongest evidence that the RED measured the property:
+
+```
+1. on the fixed branch → GREEN
+2. revert ONLY the fix (the <Suspense> push-down) → RED
+3. re-apply → GREEN
+4. confirm no other change moves it
+```
+
+Link the two runs (or include the toggle diff and results) in the PR description. A reviewer who
+sees the differential knows the test measures the property.
+
+## `instant()` is not a stopwatch
+
+See: [`instant()`](https://nextjs.org/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests).
+
+The test does not measure how fast a navigation is. `instant()` gates dynamic data so the content
+of the static shell can be asserted; the signal is presence, not speed. Under the lock, an instant
+route's shell is present, and a blocking route's content never commits, regardless of wait time.
+Therefore:
+
+- The shipped assertion is `await expect(SHELL_MARKER).toBeVisible()` under the lock. Do not add a
+  custom timeout or a `painted` boolean.
+- A custom short timeout (e.g. `3000`) implies a race against a clock that does not exist. It adds
+  nothing to the verdict and invites false REDs on an instant route whose commit lands a microtask
+  late.
+- Do not use `locator.isVisible({ timeout })` as a soft wait: Playwright deprecated and ignores
+  that timeout; the call returns immediately.
+- "Renders for the test user" (checks 7-9) is established at authoring time with the unlocked
+  baseline scaffold, not by a timed assertion in the shipped test.
+
+## `instant()` guards need no retries and no prefetch warming
+
+An `instant()` guard is deterministic. Do not configure retries on one, and do not hover-warm to
+help a prefetch land in time. Under the lock, the router initiates the route prefetch and awaits it
+before committing (even for a `prefetch={false}` link, even for a route already in the prefetch
+cache), so the committed shell does not depend on any prior render, hover, or menu-open prefetch.
+A flaky guard has a real cause: a marker that is not a sync node of the destination's shell, a
+flag/role/empty-state gap for the test user, or a genuinely blocking route. The fix is in the page or
+the marker; a retry masks the regression the guard exists to catch. The only legitimate
+`.hover()`/menu-open is when the trigger element itself is not in the DOM until hovered or opened.
+
+## Silent no-op: the testing API must be exposed in the measured build
+
+`instant()` works by setting a cookie (`next-instant-navigation-testing`) that lock code inside the
+build reads. It does not throw when that lock code is absent; it only throws on nested calls or an
+unknown base URL. If the build was produced without the testing API
+(`experimental.exposeTestingApiInProductionBuild`), the cookie is ignored, the navigation runs
+normally, and the `instant()` test passes vacuously. A green `instant()` test is only meaningful if
+the lock engaged.
+
+Two defenses; use both:
+
+1. **Confirm the API is exposed on the target.** Wire the flag to the platform's preview/staging
+   condition or an explicit environment variable; the rig file records the project's spelling
+   (SKILL.md phases 0 and A). Do not trust a pass from a build where it is not set.
+2. **Make the test self-validating**: for any route with deferred content, also assert that the
+   deferred content is gated under the lock, not only that the shell is present
+   (`test-template.md`, self-validating variant). If the lock did not engage, the content is
+   already present and `toHaveCount(0)` fails.
+
+   The gated half holds under the lock for both navigation types regardless of warm state: the
+   soft-nav client lock gates dynamic-data writes, and on an initial load the server honors the
+   cookie on the document request and suspends dynamic data. A vacuous pass is only possible with
+   a build produced WITHOUT the testing API, which defense #1 above covers.
+
+## Determinism and the rig
+
+- Always measure on a production build, never `next dev`; SKILL.md phase A owns this invariant and
+  its rationale.
+- Run the RED several times; an intermittently red gate is not a gate. If it flakes, determine
+  whether the cause is infrastructure (transient errors) or a real race before trusting either
+  color.

--- a/.agents/skills/next-cache-components-optimizer/rig-template.md
+++ b/.agents/skills/next-cache-components-optimizer/rig-template.md
@@ -1,0 +1,105 @@
+# Rig discovery: generate this project's `instant-nav.rig.md`
+
+The skill's principles are environment-independent. Your build, deploy, auth,
+and test infrastructure are not. This phase converts the principles into THIS
+project's concrete workflow: run discovery once per repo, write the answers to
+a committed `instant-nav.rig.md` (repo root, or next to your e2e config), and
+every later run reads that file instead of rediscovering.
+
+The skill is deliberately opinionated about **what** the rig must provide, and
+deliberately unopinionated about **how** your stack provides it.
+
+## How to discover
+
+Inspect before asking. Most answers are already in the repo:
+
+- `package.json` scripts (`build`, `start`, `test:e2e`)
+- the e2e config (`playwright.config.*`: `baseURL`, `webServer`, projects)
+- CI config (`.github/workflows/`, `vercel.json`, GitLab/Circle files,
+  Dockerfiles)
+- `next.config.*` (existing `experimental` flags)
+- existing e2e auth helpers (grep for `login`, `storageState`, `session`)
+
+Ask the user only what the repo can't answer. Typically that means: which
+deploy target counts as "preview", which account the suite runs as in CI, and
+whether an agent is allowed to push and wait on CI unattended.
+
+## The six questions (all must have answers), plus two derived fields
+
+The six questions below must all have answers. The rig file template adds two
+more fields the discovery feeds rather than asks directly: **LIVENESS** (the
+SHA-echoing probe, derived from the LOOP answer) and **WALLS** (project-specific
+build/run obstacles, accumulated as you first hit them).
+
+1. **BUILD**: how is a production build of this app produced and served?
+   A per-push preview deploy, a staging container, or bare
+   `next build && next start`. Anything but `next dev`.
+2. **EXPOSE**: what condition turns on
+   `experimental.exposeTestingApiInProductionBuild` for every measured build,
+   and never for real production? Spellings: an explicit
+   `EXPOSE_TESTING_API=1` for local production builds; `process.env.DEPLOY_ENV
+=== 'staging'` for a generic CI/staging env var; `process.env.VERCEL_ENV ===
+'preview'` on Vercel.
+3. **RUN**: how is the Playwright suite invoked, and against which
+   `BASE_URL`?
+4. **TEST USER**: which account does the suite run as, and how does login
+   happen (helper, `storageState`, API token)? What flags / plan / role / data
+   does that account have?
+5. **DRIFT**: enumerate everything that can differ between the author's own
+   session and the test user's environment (feature flags, plans and
+   entitlements, roles, seeded vs empty data, locale, A/B buckets). Every item
+   is a way a RED can become untrustworthy; this list feeds the C-gate
+   (`reference/red-test-robustness.md`).
+6. **LOOP**: the unattended iteration for your rig. Push → build → e2e
+   against the artifact → read the failure → fix → push (CI), or build → start
+   → e2e (local). Note anything an agent cannot do alone (deploy approvals,
+   secrets, protected branches). Include the **liveness probe**: the endpoint
+   or response header that echoes the deployed commit SHA (e.g. a `/healthz`
+   route or an `x-deployed-sha` header), so a CI run can confirm the build
+   under test matches `HEAD` before trusting a verdict (SKILL.md phase A). If
+   the platform exposes no SHA-echoing endpoint or header, add one: surface a
+   build-time commit var (`VERCEL_GIT_COMMIT_SHA`, a CI commit variable) on a
+   `/healthz` route or a response header, or fall back to polling the deploy
+   platform's API for the deployment whose `commitSha === HEAD`. Record the
+   chosen mechanism. For a local `build && start` rig the artifact is the one
+   freshly built, so no SHA probe is needed. Record the port, stop the previous
+   server before starting, fail the loop on `EADDRINUSE`, and verify the newly
+   started process owns the port before running the test.
+
+## The file: copy, fill, commit as `instant-nav.rig.md`
+
+```md
+# instant-nav rig: <project>
+
+- BUILD: <command / platform that produces the measured production build>
+- EXPOSE: <the condition wired to exposeTestingApiInProductionBuild>
+- RUN: <e2e command> against <how BASE_URL is obtained>
+- TEST USER: <account> via <login mechanism>; flags/plan/role/data: <...>
+- DRIFT: <the enumerated drift surface>
+- LOOP: <push → CI → e2e, or local build → start → test>; agent limits: <...>
+- LIVENESS: <endpoint/header echoing the deployed SHA; n/a for local build && start>
+- WALLS: <project-specific build/run obstacles + their workarounds>
+```
+
+Real apps rarely build for production cleanly on the first attempt: missing
+secrets, server-only imports that fail prerender, ports held by respawning
+servers. Record each wall and its workaround the first time you hit it. `WALLS`
+accumulates the project-specific build/run obstacles that the other fields
+cannot capture.
+
+## Filled examples
+
+**No CI / local-only.** BUILD: `EXPOSE_TESTING_API=1 next build && next
+start`. EXPOSE: that env var. RUN: `BASE_URL=http://localhost:3000 playwright
+test`. LOOP: build → start → test on one machine; fully agent-drivable, with
+nothing to push, no secrets, and no deploy wait.
+
+**Generic CI + container.** BUILD: the pipeline builds an image and deploys it
+to a staging namespace. EXPOSE: `process.env.DEPLOY_ENV === 'staging'`. RUN: a
+CI job runs Playwright against the staging URL. LOOP: push → pipeline → e2e;
+fully agent-drivable once the pipeline is wired.
+
+**Vercel preview deploys.** BUILD: every push builds a preview. EXPOSE:
+`process.env.VERCEL_ENV === 'preview'`. RUN: `playwright test` with
+`BASE_URL=<preview URL>`. LOOP: push → preview → e2e; fully agent-drivable
+once the preview deploy and `VERCEL_ENV` gating are in place.

--- a/.agents/skills/next-cache-components-optimizer/test-template.md
+++ b/.agents/skills/next-cache-components-optimizer/test-template.md
@@ -1,0 +1,167 @@
+# Test template: the instant() guard
+
+See: [`@next/playwright` `instant()`](https://nextjs.org/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests).
+
+Ship one test per navigation type you are guarding: under `instant()`, assert that the
+destination's static shell appears. `instant()` gates dynamic data, so a correctly instant route
+commits its shell under the lock and a blocking route does not. `instant()` is a ruler, not a
+stopwatch: do not add custom timeouts or timing races (see `reference/red-test-robustness.md`).
+Whether the marker is the right one (rendering for the test user, not flag-gated, not redirected
+away, not guessed) is established at authoring time with the unlocked baseline scaffold below
+(phase B, the C-gate), not by additional assertions in the shipped test.
+
+All identifiers in angle brackets (`<b>`, `<Trigger>`) and the `../helpers` import are placeholders;
+substitute your project's e2e auth helper, URL helper, and real testids/trigger before running.
+
+## Soft navigation (client-side navigation)
+
+Drive a real `<Link>` click. The committed shell is the destination's prefetched App Shell.
+Under the lock the router initiates and awaits the route prefetch itself, so no manual warming is
+needed; if the shell is intermittently absent, treat it as a real blocker or marker bug (C-gate),
+never as a warming race. Do not add waits or hovers.
+
+```ts
+import { test, expect } from '@playwright/test'
+import { instant } from '@next/playwright'
+// Use the auth/setup helpers your e2e suite already has. Run as the test user
+// (defined in SKILL.md phase B).
+import { logIntoTestAccount, testUrl } from '../helpers'
+
+// A SYNC element of the destination's static shell (header, action button,
+// column header), not data that streams in, and one that renders for the
+// test user (not gated by a flag, plan, role, or empty state). Prefer a
+// data-testid on a known static node over a guessed role/name.
+const SHELL_MARKER = '[data-testid="<b>-shell-marker"]'
+
+test.describe('instant nav: A -> B', () => {
+  test.beforeEach(async ({ page, browser }) => {
+    await logIntoTestAccount(page, browser)
+  })
+
+  test('B shell commits under instant()', async ({ page }) => {
+    await page.goto(testUrl('/'))
+    const trigger = page.getByRole('link', { name: '<Trigger>', exact: true })
+    await expect(trigger).toBeVisible({ timeout: 20000 })
+
+    await instant(page, async () => {
+      await trigger.click()
+      // static shell asserted under the lock; no timeout
+      await expect(page.locator(SHELL_MARKER)).toBeVisible()
+    })
+  })
+})
+```
+
+The trigger selector follows the same rule as `SHELL_MARKER`: prefer a `data-testid` on the real
+`<Link>` (`page.getByTestId('<trigger>-link')`) over a guessed accessible name. `getByRole({ name })`
+is shown only for brevity; like the marker, the trigger must reliably resolve for the test user.
+
+## Initial load (hard navigation)
+
+Drive `page.goto()` inside `instant()` with the `baseURL` option. The served document is the
+route's prerendered static shell. `baseURL` is required because `page` is still `about:blank` when
+`instant()` runs (`resolveURL` falls back to `page.url()` only when no `baseURL` is passed).
+Establish the session WITHOUT navigating `page` (inject `storageState`, or log in on a separate
+context/page). A login helper that navigates `page` itself defeats the measurement for a different
+reason: that navigation completes before `instant()` acquires the lock, so it runs unmeasured. The
+session must be pre-established either way; otherwise an authenticated route redirects to login
+and the RED is false.
+
+If the project's only login helper navigates `page`, the agent must use a
+storageState/separate-context path here instead, a session-injection call that
+does NOT call `page.goto`:
+
+```ts
+test.describe('instant initial load: B', () => {
+  test.beforeEach(async ({ page }) => {
+    await injectTestUserSession(page) // storageState only; must NOT call page.goto
+  })
+
+  test('B shell is served', async ({ page }) => {
+    const url = testUrl('/<b>')
+    await instant(
+      page,
+      async () => {
+        await page.goto(url)
+        await expect(page.locator(SHELL_MARKER)).toBeVisible()
+      },
+      { baseURL: new URL(url).origin }
+    )
+  })
+})
+```
+
+## Self-validating variant (recommended for routes with deferred content)
+
+Also assert that the deferred content is gated under the lock and streams after release. This
+makes a vacuous pass impossible: if the lock did not engage (testing API missing from the build),
+the content is already present and `toHaveCount(0)` fails (see `reference/red-test-robustness.md`).
+
+`SHELL_MARKER` is the shell node; `[data-testid="<b>-content"]` is the deferred data it guards.
+
+```ts
+// soft navigation
+await instant(page, async () => {
+  await trigger.click()
+  await expect(page.locator(SHELL_MARKER)).toBeVisible() // shell present
+  await expect(page.getByTestId('<b>-content')).toHaveCount(0) // deferred data gated
+})
+await expect(page.getByTestId('<b>-content')).toBeVisible() // streams after release
+```
+
+The two **gated-half** assertions (shell visible, deferred content `toHaveCount(0)`) apply to the
+initial-load `page.goto()` form too. The cookie gates the deferred content identically for both:
+on a soft navigation the client lock gates dynamic-data writes; on an initial load the server
+honors the cookie on the document request (set via `addCookies()` before navigation, scoped by
+`baseURL`) and suspends dynamic data, independent of whether the route was previously rendered or
+cached. So the initial-load `toHaveCount(0)` gated half is as valid as the soft-nav one; it needs
+no fresh browser context and no cache-busting query param.
+
+The **post-release** assertion (`getByTestId('<b>-content').toBeVisible()` after the `instant()`
+block) is soft-nav only. On an initial load the document was already emitted under the lock, so
+nothing streams in after release; drop that assertion from the initial-load test, or
+`page.reload()` first to fetch an unlocked document. The mechanism is in
+`reference/red-test-robustness.md`.
+
+## Baseline scaffold: do not ship
+
+Before optimizing, confirm the target exists with an unlocked check (no `instant()`). It
+disambiguates "not instant" from "marker absent for this user or environment". Run it as the test
+user; mismatch against the rig DRIFT list is what the C-gate catches
+(`reference/red-test-robustness.md`). Confirm the marker is real and reachable, then delete the
+scaffold before the PR.
+
+**The baseline must mirror the navigation type of the test you are shipping.** Drive a `<Link>`
+click when guarding the soft-nav shell; drive `page.goto()` when guarding the initial-load shell.
+The two shells can differ (`reference/real-app-patterns.md`): a click-driven baseline run against a
+shipped `goto` test would confirm a marker that the `goto` path never shows, which produces exactly
+the false RED the C-gate exists to prevent.
+
+```ts
+// soft-nav baseline: mirror the soft-nav instant() test
+test('dev-only: navigating to <b> renders its shell (no lock)', async ({
+  page,
+}) => {
+  await page.goto(testUrl('/'))
+  const trigger = page.getByRole('link', { name: '<Trigger>', exact: true })
+  await expect(trigger).toBeVisible({ timeout: 20000 })
+  await trigger.click()
+  await expect(page).toHaveURL(/\/<b>(\?|$)/) // confirm the real destination (no redirect away)
+  await expect(page.locator(SHELL_MARKER)).toBeVisible({ timeout: 15000 })
+})
+```
+
+```ts
+// initial-load baseline: mirror the initial-load instant() test (session pre-established)
+test('dev-only: <b> shell is served (no lock)', async ({ page }) => {
+  await page.goto(testUrl('/<b>'))
+  await expect(page.locator(SHELL_MARKER)).toBeVisible({ timeout: 15000 })
+})
+```
+
+Notes:
+
+- Pick `SHELL_MARKER` as a sync element of the destination's static shell, never streamed data.
+  Use a `data-testid` on a known static node rather than a guessed role/name.
+- Do not put a custom timeout, a `painted` boolean, or `isVisible({ timeout })` in the shipped
+  assertion, and do not add retries or hover-warming; see `reference/red-test-robustness.md`.

--- a/.agents/skills/next-dev-loop/SKILL.md
+++ b/.agents/skills/next-dev-loop/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: next-dev-loop
+description: >
+  Verify Next.js runtime behavior after editing app code. Use this
+  skill to confirm a change actually works in a running app — not
+  just that it compiles or type-checks. Combines /_next/mcp
+  (Next.js's view) with agent-browser (the browser's view).
+  Requires a running `next dev`.
+---
+
+# next-dev-loop
+
+The edit/verify rhythm during `next dev` — make a change, then
+confirm it actually works at runtime, not only that the types or
+the build are happy.
+
+You verify through two views of the same running app:
+
+- **`/_next/mcp`** — an HTTP endpoint Next.js exposes about itself.
+  Knows framework-specific things: routes, segments, RSC, server
+  actions, server logs, and errors as Next.js saw them. Call
+  `tools/list` for the current surface.
+- **`agent-browser`** — a CLI that drives a real Chrome. Knows
+  framework-agnostic browser things: DOM, console, network, React
+  fiber, vitals. Before driving it, run `agent-browser skills get core`
+  once for the version-matched usage guide — don't guess subcommands
+  from memory.
+
+The two views cross-check each other.
+
+## requires
+
+- Next.js **16.3+** with **Turbopack** — `/_next/mcp` plus the
+  proactive compile check via `get_compilation_issues`.
+- `agent-browser` **>= 0.31.1** — React introspection, worktree-scoped
+  `session id`, idempotent `--restore`, and launch flag reconciliation.
+
+These are hard floors, not soft preferences. If anything is missing,
+tell the user how to upgrade and stop. Don't fall back to grepping
+source or to a weaker probe — this skill assumes both views are live
+at the versions above.
+
+- Upgrade Next.js: `pnpm next upgrade` (or `npx next upgrade`).
+  Docs: https://nextjs.org/docs/app/getting-started/upgrading
+  (version-16 guide:
+  https://nextjs.org/docs/app/guides/upgrading/version-16)
+- Install or upgrade `agent-browser`: `npm i -g agent-browser@latest`.
+  If the CLI isn't on `PATH`, install it before continuing — preflight
+  expects to invoke it directly.
+
+## preflight
+
+Once per session, confirm both views are live.
+
+1. **Open `agent-browser` at the target URL, restoring saved
+   login state when present.** First derive one stable session id for
+   this checkout and use it for every `agent-browser` command:
+
+   ```bash
+   SESSION="$(agent-browser session id --scope worktree --prefix next-dev-loop)"
+   export AGENT_BROWSER_SESSION="$SESSION"
+   export AGENT_BROWSER_RESTORE="$SESSION"
+   ```
+
+   Then open the target URL:
+
+   ```bash
+   agent-browser --session "$SESSION" --restore --headed --enable react-devtools open <url>
+   ```
+
+   `--scope worktree` keeps parallel worktrees and copied checkouts
+   from colliding. Bare `--restore` uses the session id as the
+   persistence key, loads saved cookies/localStorage before navigation
+   when present, and auto-saves state on close. Always pass the desired
+   launch flags on `open`; agent-browser will reuse, relaunch, or restart
+   its scoped background state as needed.
+
+   The browser is the user's. If state was not restored (first run,
+   expired session) and the page is gated, the user drives the login —
+   pause until they confirm. After login, continue using the same session
+   and restore context; `agent-browser close` saves the cookie state so
+   the next `open` restores it.
+
+2. Probe `/_next/mcp` (`tools/list`) — confirm it's reachable and
+   lists `get_compilation_issues`. First read the port off the
+   `next dev` banner; if it isn't 3000, set
+   `NEXT_MCP_URL=http://localhost:<port>/_next/mcp` before probing:
+   - Unreachable → either `next dev` isn't running, or Next.js is
+     below 16.3. Check `package.json` to disambiguate, then refuse.
+   - `get_compilation_issues` not in the list → Next.js below 16.3.
+     Refuse and tell the user to upgrade.
+3. `get_compilation_issues` doubles as a Turbopack probe. An error
+   response of `"Turbopack project is not available..."` means the
+   user is on webpack. Refuse — Turbopack is required.
+4. `get_routes` → your route map for the rest of the session.
+
+## loop
+
+### before the edit — narrow the scope
+
+Ask the running app, not the codebase. `/_next/mcp` knows which
+files rendered the current route; use those as your search scope.
+Runtime introspection stays cheap as the codebase grows; agentic
+search doesn't.
+
+### after the edit — verify
+
+Four failure modes. Check each:
+
+- **Compiles** — `get_compilation_issues`.
+- **Runs without errors** — `/_next/mcp` (server and bubbled-up
+  browser errors both surface here).
+- **Behaves as intended** — `agent-browser` drives the page; assert
+  what the user actually sees.
+- **React-level behavior** — `agent-browser` with react-devtools
+  enabled exposes the component tree, props, state, and render
+  counts. Anchor framework-level checks here (extra renders,
+  server/client boundary shifts, suspense fallbacks) — DOM asserts
+  alone miss them.
+
+Pick the specific tool from `tools/list` or the agent-browser
+manual rather than from memory.
+
+## gotchas
+
+- **Every `agent-browser` command must know your session and restore
+  key, or it may use an empty default browser or fail to save login
+  state.** Easiest: export both `AGENT_BROWSER_SESSION="$SESSION"` and
+  `AGENT_BROWSER_RESTORE="$SESSION"` at the top of each shell you run
+  agent-browser in. If you do not export them, pass
+  `--session "$SESSION" --restore` on every command.
+- **When the two views disagree, suspect the tooling first.** If
+  `agent-browser` says a route is broken but `/_next/mcp` and the
+  server say it rendered cleanly, a stale or misdirected browser
+  session is the likelier cause than a real bug — reconcile the views
+  before debugging the app.
+- Confirming a click or navigation: the page settles a beat later, so
+  wait with `wait --load networkidle` (no path to get wrong), then
+  snapshot/read to confirm the page. Avoid `wait --url` unless you pass
+  the link's exact href — a guessed or placeholder path won't match the
+  real URL and times out after 25s.
+- A blank read, empty snapshot, `about:blank`, or a "no browser
+  session" error — right after `open` or after a click (even if `open`
+  reported the page) — is the browser dropping the page (a stale
+  session), not a broken route. Reopen your session at the URL with
+  `--session "$SESSION" --restore` and re-snapshot; if still blank,
+  run `agent-browser --session "$SESSION" --restore close`, then open
+  again. Don't fall back to `curl`; it bypasses the browser you're
+  testing.
+- React introspection output is stale after navigation. Re-run.
+- `/_next/mcp` replies are SSE — read the JSON off the `data:` line
+  with `sed -n 's/^data: //p'` (a plain `sed 's/^data: //'` leaves the
+  `event:` line and the parse fails).
+- `get_errors` and `get_page_metadata` need at least one navigation
+  to populate.
+
+## reference
+
+All tools below are present once preflight passes. If `tools/list`
+is missing any of them, preflight should have refused — re-check.
+
+```
+# /_next/mcp                 notes
+get_project_metadata         projectPath, devServerUrl, bundler
+get_routes                   fs-scan; no browser session needed
+get_errors                   runtime + build; needs a browser session;
+                             includes browser-side errors caught by the
+                             dev server
+get_page_metadata            segment trie + routerType; needs a browser
+                             session; use as a discovery shortcut for
+                             which files power a route
+get_logs                     returns logFilePath
+get_server_action_by_id      hashed id → file + functionName
+get_compilation_issues       Turbopack only; errors on webpack
+                             ("Turbopack project is not available")
+```
+
+## teardown
+
+Close the session with the same session and restore context:
+`agent-browser --session "$SESSION" --restore close`. `close` saves
+that session's cookies and storage so the next loop's `--restore` open
+keeps the user logged in. Leave `next dev` up for the next loop.
+
+---
+
+`next-dev-loop-<topic>` siblings (e.g. `next-dev-loop-rsc`, `next-dev-loop-debug`)
+assume this preflight already ran; they pick up at the loop.

--- a/.agents/skills/next-partial-prefetching-adoption/SKILL.md
+++ b/.agents/skills/next-partial-prefetching-adoption/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: next-partial-prefetching-adoption
+description: >
+  Turn on Partial Prefetching in a Next.js app and work through the
+  insights it surfaces. Use when the user wants to enable or adopt
+  Partial Prefetching, flip the `partialPrefetching` flag, opt routes
+  in with `export const prefetch = 'partial'`, audit
+  `<Link prefetch={true}>` calls, or resolve the
+  link-prefetch-partial and instant-shell-url-data insights.
+---
+
+# next-partial-prefetching-adoption
+
+Enable Partial Prefetching and walk the app until every link reuses a shared App Shell. This skill sequences the work; per-insight recipes live in the dev overlay fix cards and their docs pages. The [Adopting Partial Prefetching guide](https://nextjs.org/docs/app/guides/adopting-partial-prefetching) is the canonical reference for the concepts this skill applies.
+
+The one thing that shapes everything below: **these insights surface only in `next dev`, in the dev overlay's Insights tab.** Nothing fails the build. There is no build-only fallback loop — confirming an insight is _cleared_ means driving the running app in a browser. But a missing browser gates that verification, not the whole skill: the adoption work is static and runs from the guide, so do the static pass anyway and hand off the live shell check.
+
+Talk to the user in terms of what they'll see — PRs, features, and how the app behaves after — never the insight slugs or step labels. Before you start, tell them briefly what Partial Prefetching changes: a `<Link>` loads a shared App Shell, and `prefetch={true}` no longer prefetches everything the old full prefetch did.
+
+## requires
+
+- **Cache Components on (`cacheComponents: true`).** This is the only hard requirement; `partialPrefetching` depends on it. Full Cache Components adoption is the ideal starting point but not a gate. Nothing in this skill blocks the build, and neither do the prerender insights an unadopted route surfaces, like a leftover `unstable_noStore` or a `cookies()` read outside `<Suspense>`: they are non-blocking dev signals, expected on any fresh branch off `main`, not a reason to stop. They replace the URL-data insight only on their own route in the [step 3](#step-3-sweep-for-url-data-insights-after-enabling) sweep; the flag-off step 1 audit and its static adoption run regardless. The only thing that actually stops this skill is a build-blocking failure, and anything build-blocking would have been resolved before you reached here. Otherwise fix the prerender insights you hit as inline [`next-cache-components-adoption`](https://github.com/vercel/next.js/tree/canary/skills/next-cache-components-adoption) work, or hand them off, and keep going.
+
+- **Next.js 16.3 or later.** `partialPrefetching`, the `prefetch` route segment config, and the prefetch insights all land there.
+
+- **A browser you can drive.** Install [`next-dev-loop`](https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop) before starting (`npx skills add https://github.com/vercel/next.js/tree/canary/skills/next-dev-loop`). Install it without asking — it's a tool, not a product change — and don't assume it's blocked: verify a real blocker (no network, no npm, read-only filesystem) before falling back, and name it in your report. Link prefetches fire when a link renders and enters the viewport, and shell validation fires on navigation — neither is reachable from `curl` or the build. If the app is webpack-pinned, drive a browser directly (`agent-browser`, Playwright) — you lose the framework cross-checks, not the insights; they're still in the overlay and the dev log.
+
+- **A runnable app.** Verification runs against `next dev` for the insight sweep and a production `next build`/`next start` for prefetching (prefetching is prod-only), so the app has to boot in both. If it reads a database or required env at import (e.g. an `env.ts` that throws on a missing `DATABASE_URL`), confirm it starts — with the real environment, or local data you stand up — before step 1. An app that won't run can't be swept or verified.
+
+### notes
+
+- **Offline docs.** Guide links have offline copies under `node_modules/next/dist/docs/` (bundled since Next.js 16.2), with the directory layout numbered for ordering (e.g. `node_modules/next/dist/docs/01-app/02-guides/adopting-partial-prefetching.md`). If you can't predict the numbered prefix, `find node_modules/next/dist/docs -name '<slug>.md'` resolves it. The `/docs/messages/*` error pages are not bundled.
+
+- **Older versions without bundled docs.** Suggest `npx @next/codemod@latest agents-md` to the user before starting: it downloads a version-matched copy to `.next-docs/` and writes an index into `AGENTS.md` / `CLAUDE.md`. It touches files in their repo, so ask first and run it only if they want it.
+
+## background
+
+Adopting Partial Prefetching means every route still delivers what its links prefetched before, now split between the shared App Shell and any extra per-link data a link explicitly asks for. The [guide](https://nextjs.org/docs/app/guides/adopting-partial-prefetching) is the canonical reference for what a prefetch contains and how to decide each case; this skill sequences that work against a running app.
+
+The catch that decides most of the sweep: a default link warms only the shared App Shell. A route keyed by `params` or `searchParams` can prefetch more only after it has adopted Partial Prefetching and a specific link uses [`<Link prefetch={true}>`](https://nextjs.org/docs/app/api-reference/components/link#prefetch); then Next.js resolves the URL data and any cached content behind it before the click (the guide's [URL data](https://nextjs.org/docs/app/guides/adopting-partial-prefetching#url-data) section).
+
+## working surfaces
+
+- **The dev server terminal — your primary record.** Each validated route's insights are logged as `Error: Route "...": Next.js encountered ...` lines with the `https://nextjs.org/docs/messages/<slug>` link. Tail the dev log during the sweep; it's the greppable record of what fired where, and it works the same on Turbopack and webpack.
+- **The dev overlay Insights tab.** Insights are the amber, non-blocking tab. It appears only once an insight has fired, so a route that surfaces nothing shows no tab at all — that's the clean state, not a missing feature. Don't hunt for the tab on a quiet route; confirm clean from the dev log above, which is the reliable signal. The precondition is no blocking-prerender errors — those replace the insight on their route (see requires). An unrelated Issue (a hydration error, a console error) doesn't block the sweep; don't stall on it. When the tab is present, the overlay pill shows the count and each insight has fix cards linking its docs page. The overlay renders inside a shadow root (`nextjs-portal`), so accessibility-tree snapshots don't see it — evaluate into `shadowRoot` when you need to read or click it programmatically.
+- **`next-dev-loop`** to drive navigations and read the overlay. Prefer it over hand-rolled browser automation for the same reasons as in the Cache Components skill (webpack apps: see requires). When browsing its `/_next/mcp` tools, the prefetch insights surface through `get_errors` and the overlay, not the similarly-named `get_request_insights`. That one is the span and performance recorder (gated behind `experimental.requestInsights`) and reports nothing about prefetching.
+
+Every insight has a docs page — open it. Fetch the linked page for every distinct insight you encounter; the inline message is a summary, the page is the recipe.
+
+## step 1: audit `<Link prefetch={true}>` (before enabling)
+
+If `partialPrefetching: true` is already set in `next.config.ts`, the app is adopted — skip to [step 3](#step-3-sweep-for-url-data-insights-after-enabling). Otherwise work the audit with the global flag **off**, adopting each destination with `export const prefetch = 'partial'` — enabling the flag first would mark every route adopted and silence the [`link-prefetch-partial`](https://nextjs.org/docs/messages/instant-link-prefetch-partial) insight this audit runs on. Ask the user how to ship it, in the language of PRs:
+
+- **One branch** — the whole audit in one change, with the flag enabled and the codemod run at the end (step 2).
+- **Route by route** — each adopted destination ships as its own PR. The insight still fires for the destinations you haven't reached, a live worklist, and step 2 comes after the last one.
+
+The work is identical either way — only the commit boundaries differ. Default by app size: one branch for a handful of links, route by route when the audit is big enough that reviewers need smaller diffs. Note the choice in your report.
+
+Enumerate the prefetch sites across the whole source tree, not only `app/` — they often live in `src/components` or shared UI packages: `rg -n '\bprefetch\b|router\.prefetch' -g '*.tsx' -g '*.jsx' .`. Keep the `<Link prefetch={true}>` and bare-prop matches (a bare prop is `true`) as the over-prefetching links this audit adopts destinations for, and drop `prefetch={false}` and other values. Also audit existing imperative [`router.prefetch()`](https://nextjs.org/docs/app/api-reference/functions/use-router#userouter) call sites with the same table, because they can be preserving the same "fetch before navigation" behavior and have no dev insight. For new navigation prefetching, prefer [`<Link>`](https://nextjs.org/docs/app/api-reference/components/link), which the docs call the primary navigation API; use [`router.prefetch()`](https://nextjs.org/docs/app/guides/prefetching#manual-prefetch) only for manual prefetching. If the app already passes an internal `kind` option, treat that as existing implementation detail, not a pattern to spread. If nothing matches, check for a custom link wrapper before calling the audit empty. If there's still nothing, say so in your report and move on to [step 2](#step-2-enable-the-flag).
+
+Then, for each one:
+
+1. **Click each `<Link>` in `next dev`.** The insight fires at navigation time, not when the link prefetches, so a link sitting in the viewport won't trip it — you have to navigate through it. This click is _verification_: it confirms the insight fires before you adopt and clears after. Imperative `router.prefetch()` sites have no equivalent insight, so audit them from source and verify them in production ([step 4](#step-4-verify)). Without a browser, skip the click and adopt from [`link-prefetch-partial`](https://nextjs.org/docs/messages/instant-link-prefetch-partial) and the audit table below — the destination's structure tells you the row, and type-check gates the edit — then leave the live confirmation for the hand-off.
+2. **Adopt the destination.** Add the temporary route config with a link to the migration guide. That clears the insight for every link pointing at it:
+
+   ```tsx
+   // See: https://nextjs.org/docs/app/guides/adopting-partial-prefetching
+   export const prefetch = 'partial'
+   ```
+
+   If the route reads URL data (`params`, `searchParams`), the default link still warms only its skeleton (the guide's [URL data](https://nextjs.org/docs/app/guides/adopting-partial-prefetching#url-data) section), so it's a runtime-prefetch candidate for step 5, not a finished adoption. Keep `prefetch={true}` on its links and mark the route:
+
+   ```tsx
+   // TODO(runtime-prefetch): assess with the user whether URL data should resolve before click.
+   // See: https://nextjs.org/docs/app/guides/runtime-prefetching
+   export const prefetch = 'partial'
+   ```
+
+   Use that exact prefix so step 5 can grep them back. Don't cache or decide anything for these routes now.
+
+3. **Preserve what that prefetch delivered.** The guide's [audit table](https://nextjs.org/docs/app/guides/adopting-partial-prefetching#auditing-link-prefetchtrue-calls) is the canonical decision — fetch it and apply the matching row. Caching uncached content is the judgment call in that table: trace where the data comes from and what freshness and revalidation it needs, per the [`use cache`](https://nextjs.org/docs/app/api-reference/directives/use-cache) docs, and ask the user when the answer isn't clear-cut. The URL-data routes you marked in the previous item wait for step 5.
+
+> **If you add `use cache`, verify under `next start`, not only the build.** A `cookies()`/`headers()`/session read anywhere in the cached call tree throws at request time while `next build` passes clean. See [`use cache`](https://nextjs.org/docs/app/api-reference/directives/use-cache).
+
+## step 2: enable the flag
+
+Once every audited destination has `prefetch = 'partial'`, finish in two moves.
+
+1. **Enable the flag globally.** Set `partialPrefetching: true` in `next.config.ts` (alongside `cacheComponents: true`). Every route is adopted now, so every link is good.
+2. **Strip the redundant `prefetch = 'partial'` exports.** Run the first-party `remove-partial-prefetch` codemod rather than a text find-and-replace. It removes only `export const prefetch = 'partial'` and its generated Partial Prefetching guide comment. It leaves other values such as `prefetch = 'force-disabled'` in place, along with your `TODO(runtime-prefetch)` markers and their Runtime Prefetching guide links, which wait for step 5.
+
+   ```bash
+   npx @next/codemod@latest remove-partial-prefetch ./app
+   ```
+
+   The codemod refuses to run on a dirty working tree. Commit or stash unrelated work first, or pass `--force` to let its edits land alongside your WIP. If the codemod isn't available (older `@next/codemod`, sandboxed environment, offline run), reproduce it by hand by removing `export const prefetch = 'partial'` and its generated Partial Prefetching guide comment from every `app/**/{page,layout}.{js,jsx,ts,tsx}` — leave other `prefetch` values in place, and leave the `TODO(runtime-prefetch)` markers and Runtime Prefetching guide links where they are. Don't hand-edit when the codemod can run.
+
+## step 3: sweep for URL-data insights (after enabling)
+
+This is a dev-only second pass. The shell check runs only with the flag on, fires at navigation time, and never blocks the build, so it can happen any time after step 2. Build the route queue from a concrete source (the last `next build` route table, or the `app/` tree) and keep it as a todo list.
+
+Sweep feature by feature. A feature is a single product surface — `app/settings/**`, `app/posts/[slug]/**` — not a whole top-level area. Finish one end-to-end before starting the next: load its routes in `next dev` and resolve their insights. The insight never blocks the build and each route is independent, so a partial sweep leaves a working app, and each feature is a self-contained change the user can review or ship on its own.
+
+If the environment can't finish the whole sweep (slow first compiles, a dev server that falls over under load, no browser at all), take the browser-free work as far as it goes before handing off. Adopt every route you can statically: apply the fix from [`URL data`](https://nextjs.org/docs/messages/instant-shell-url-data) (up to a new `<Suspense>` boundary) and opt the route into `prefetch = 'partial'`, gating on type-check. Work the whole queue in one pass — a larger refactor isn't a reason to defer, and asking whether to continue to the next route or tier isn't a checkpoint; keep going. Stop only for a genuine judgment call, and batch those into the single hand-off report: the routes you statically adopted, the ones still needing a live shell check, and the queue.
+
+Watch the Insights tab and the dev log for `Next.js encountered … data` lines. The signal this step adds is [`URL data`](https://nextjs.org/docs/messages/instant-shell-url-data): a `params` or `searchParams` read too high in the suspended subtree ties the shared shell to one URL. This insight is narrow; it most reliably appears on a `generateStaticParams` route where `params` is already under `<Suspense>`, but still awaited before the URL-specific leaf boundary. If a `blocking-prerender-*` error fires instead, apply the same structural fix.
+
+Loading a route with the flag on prerenders its App Shell, which validates more of the route than the Cache Components build did. So a route that built cleanly under Cache Components (every route `◐`, no errors) can still surface a `blocking-prerender-*` error here the first time its shell is prerendered — [`runtime data`](https://nextjs.org/docs/messages/blocking-prerender-runtime) (`cookies()`/`headers()`), [`uncached data`](https://nextjs.org/docs/messages/blocking-prerender-dynamic) (an uncached `fetch`/DB call), or sync IO like `Date.now()`/`new Date()`. This doesn't mean the Cache Components adoption was incomplete; it's new validation reaching a path the build never exercised. These aren't Partial Prefetching insights — fix each one the same way you would any blocking-prerender error.
+
+These fixes rarely involve the user — each insight names the offending read and its docs page has the fix, so apply it and keep sweeping. Collect the rare exceptions for one batched question at the end: a page that is entirely one URL-dependent region (wrapping it all leaves an empty shell), or a route that should arguably stay opted out. Don't narrate the refactor with comments — the `<Suspense>` boundaries speak for themselves.
+
+## step 4: verify
+
+Checklist before checking in with the user:
+
+- **An empty sweep is expected when Cache Components adoption finished cleanly.** A quiet log is success, not a missing signal. If you deliberately probe the validation path, use a `generateStaticParams` route with `params` read inside `<Suspense>` but before the URL-specific leaf boundary; other shapes may surface `blocking-prerender-*` instead.
+- The App Shells are real: for each route you changed, confirm the first paint after a navigation shows the intended shared content, not an empty shell or a stuck fallback. A `<Suspense>` around the whole page body passes validation with an empty shell, which defeats the point.
+- The insights validate shell _structure_, not that a prefetch actually happened. Confirm on the production run (prefetching is prod-only) that navigating a changed link lands on the shared shell instantly.
+- **If the app prefetches imperatively**, the insight sweep does not cover it, so an empty sweep is not proof the prefetch survived the flag. Verify the call under `next start`: compare the `_rsc` prefetch response or resource timing before/after, and make sure any intentionally preserved full prefetch still carries the data the old call was warming. If it now returns only the App Shell, migrate that call site using the same decision as the nearest `<Link prefetch={true}>` destination — cache the data, or move runtime-prefetch behavior to a docs-supported `<Link prefetch={true}>`.
+- **Before blaming a broken route on the flag, reproduce it with `partialPrefetching` off** (or on the pre-flag branch). The flag surfaces existing issues — a fragile request-time auth gate, a rewrite, deployment skew — earlier and more visibly, but rarely causes them. If it breaks flag-off too, it isn't a Partial Prefetching problem; fix it there, not here.
+- `next build` still passes.
+
+Then check in with the user. Speak their language — no insight slugs or step labels.
+
+- What you did: which links you audited, which destinations you adopted, and what each link now prefetches.
+- What changed: dropped props, `use cache` boundaries added, and which routes carry a `TODO(runtime-prefetch)` marker for later.
+- Demo against a production run. Prefetching is limited in development, so `next dev` won't show the result — run `next build` and `next start`, and hand the user that URL. That run needs the app's real environment (database, auth, secrets), and a partial or stale install or leftover generated artifacts can fail the build for reasons unrelated to the adoption. Set the expectation up front that verification is a complete, credentialed production run, not a quick check.
+- Show, don't tell: drive one link live in the headed browser against the production server, so they see the shared App Shell paint instantly and the URL-specific region stream in. Attach before/after screenshots only when a live browser isn't possible.
+- Give them the click-through: a table of each changed route — the link to click, and what to expect after the click (what paints instantly, what streams in) — so they can verify each result themselves.
+- The question: "Want to commit this (or open the PR) before we look at which routes should also prefetch their URL-specific content?" Wait for the answer — adoption and runtime prefetching read best as their own changes.
+
+## step 5: runtime prefetching (optional)
+
+The audit marked the candidates instead of deciding them. Grep for `TODO(runtime-prefetch)` and walk the list with the user in one conversation. The question per route is whether they want the URL-dependent content prefetched ahead of the click, or streaming in after navigation is fine. A runtime prefetch costs a server invocation per prefetchable link — the guide's [per-link prefetching trade-offs](https://nextjs.org/docs/app/guides/runtime-prefetching#per-link-prefetching-trade-offs) section is the checklist. Don't make these calls alone.
+
+Where the answer is yes, follow the [runtime prefetching guide](https://nextjs.org/docs/app/guides/runtime-prefetching): keep [`<Link prefetch={true}>`](https://nextjs.org/docs/app/api-reference/components/link#prefetch) on the links that should resolve more than the App Shell, and cache the content behind the URL-data read using the guide's patterns (`use cache` with the runtime value passed in, or `use cache: private` for per-user data). Each per-link prefetch is a server render when the destination needs non-static data, so use the guide's [per-link trade-offs](https://nextjs.org/docs/app/guides/runtime-prefetching#per-link-prefetching-trade-offs) to decide when viewport prefetching is worth it and when [hover-triggered prefetch](https://nextjs.org/docs/app/guides/prefetching#hover-triggered-prefetch) is a better fit. Where it's no, delete the marker and leave the route on the App Shell default. Either way no `TODO(runtime-prefetch)` marker survives this step. Confirm the opted-in links against a production run (`next build` and `next start` — the runtime prefetch fires there, not in `next dev`), give the user the same click-through for them, and keep this as its own commit or PR.
+
+## further reading
+
+- [Instant navigation](https://nextjs.org/docs/app/guides/instant-navigation) — the broader validation model and loading-state tooling.
+- [Prevent regressions with e2e tests](https://nextjs.org/docs/app/guides/instant-navigation#prevent-regressions-with-e2e-tests) — the `@next/playwright` `instant()` helper locks in what a navigation shows immediately; recommend it once the sweep is clean, since nothing else guards these in CI.
+- [`next-cache-components-optimizer`](https://github.com/vercel/next.js/tree/canary/skills/next-cache-components-optimizer) — grows each route's static shell so the App Shell carries more.

--- a/.mcp.json
+++ b/.mcp.json
@@ -11,7 +11,7 @@
       "command": "sh",
       "args": [
         "-c",
-        "cd \"${CLAUDE_PROJECT_DIR:-.}/studio\" && set -a && . ./.env && set +a && exec npx -y mcp-remote https://mcp.sanity.io --transport http-only --header \"Authorization: Bearer ${SANITY_AUTH_TOKEN}\""
+        "cd \"${CLAUDE_PROJECT_DIR:-.}/studio\" && SANITY_AUTH_TOKEN=\"$(. ./.env >/dev/null 2>&1; printf %s \"${SANITY_AUTH_TOKEN}\")\" exec npx -y mcp-remote@0.1.38 https://mcp.sanity.io --transport http-only --header \"Authorization: Bearer \\${SANITY_AUTH_TOKEN}\""
       ]
     }
   }

--- a/.mcp.json
+++ b/.mcp.json
@@ -6,6 +6,13 @@
         "-c",
         "cd \"${CLAUDE_PROJECT_DIR:-.}/frontend\" && exec node_modules/.bin/shadcn mcp"
       ]
+    },
+    "sanity": {
+      "command": "sh",
+      "args": [
+        "-c",
+        "cd \"${CLAUDE_PROJECT_DIR:-.}/studio\" && set -a && . ./.env && set +a && exec npx -y mcp-remote https://mcp.sanity.io --transport http-only --header \"Authorization: Bearer ${SANITY_AUTH_TOKEN}\""
+      ]
     }
   }
 }

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "skills": {
+    "next-cache-components-adoption": {
+      "source": "vercel/next.js",
+      "sourceType": "github",
+      "skillPath": "skills/next-cache-components-adoption/SKILL.md",
+      "computedHash": "15dcef9cfce611ba5a9ca467ed0d4eeae8de16fadb91b66df892a5ca63c57829"
+    },
+    "next-cache-components-optimizer": {
+      "source": "vercel/next.js",
+      "sourceType": "github",
+      "skillPath": "skills/next-cache-components-optimizer/SKILL.md",
+      "computedHash": "aefb01afebac59c0359cfd15214e871d12e5d242867dc486087a4560363ee28c"
+    },
+    "next-dev-loop": {
+      "source": "vercel/next.js",
+      "sourceType": "github",
+      "skillPath": "skills/next-dev-loop/SKILL.md",
+      "computedHash": "d6c10996c5c31b32faa269715852006922fa4357d1151403bb3a49dfa121bcfd"
+    },
+    "next-partial-prefetching-adoption": {
+      "source": "vercel/next.js",
+      "sourceType": "github",
+      "skillPath": "skills/next-partial-prefetching-adoption/SKILL.md",
+      "computedHash": "cfed44cfce68b08b2a7edf3d6f07b230a49dfbf180825ca49a5bbf12b27a558a"
+    }
+  }
+}


### PR DESCRIPTION
Splits the agent tooling and vendored skill docs out of #30 so that PR stays focused on the loan-page and redirect work.

## What's here

- **Vendored Next.js agent skills** from `vercel/next.js` — Cache Components adoption/optimizer, dev-loop, and partial-prefetching guides, tracked in `skills-lock.json` with integrity hashes.
- **Sanity MCP server config** in `.mcp.json`.

## Security fix included

CodeRabbit flagged the Sanity MCP entry on #30, and it was a real problem. The original:

```
... set -a && . ./.env && set +a && exec npx -y mcp-remote ... --header "Authorization: Bearer ${SANITY_AUTH_TOKEN}"
```

Two issues:
1. The shell expanded the token into the `npx` argv, so it was readable from the process list (`ps`).
2. `set -a` exported **every** value in `studio/.env` into the subprocess, not just the token.

Now:
- The `\${SANITY_AUTH_TOKEN}` placeholder is escaped so `mcp-remote` resolves it from its own environment rather than the shell.
- Only `SANITY_AUTH_TOKEN` is loaded into that environment.
- `mcp-remote` is pinned to `0.1.38` instead of floating, closing the rug-pull risk.

Verified locally: the token still loads (correct length) and the other `studio/.env` values no longer reach the subprocess.

## On the remaining CodeRabbit findings

The other 9 findings from #30 all target the **vendored skill docs** — pinning `npx @next/codemod@latest`, resolving `app` vs `src/app`, MCP tool-contract checks, and similar.

I deliberately did **not** apply those. These files are copied verbatim from `vercel/next.js` and `skills-lock.json` stores a `computedHash` for each one. Editing them breaks the integrity check and makes every future skill sync a merge conflict. The right place for those fixes is upstream.

The findings are reasonable in substance — several would be good upstream issues — they just shouldn't be patched in a vendored copy.
