### PR TITLE
fix(studio): keep draft previews reachable and simplify rich text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ next-env.d.ts
 
 # sanity dataset exports (backups taken before destructive/verification work)
 studio/backups/
+.env*

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ next-env.d.ts
 # sanity dataset exports (backups taken before destructive/verification work)
 studio/backups/
 .env*
+!.env.example
+!.env*.example
+!.env.template
+!.env*.template

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,208 @@
+# PHXHomeLoan.com
+
+PHXHomeLoan.com is the public website of The Highly Motivated Vercellino Team.
+
+## Language
+
+### Business identities
+
+**The Highly Motivated Vercellino Team**:
+The mortgage originator behind PHXHomeLoan.com. The team is led by Jimmy Vercellino.
+
+**Mortgage Originator**:
+The role held by The Highly Motivated Vercellino Team.
+
+**Luminate Bank**:
+The lender working with The Highly Motivated Vercellino Team.
+
+**Lender**:
+The role held by Luminate Bank, which owns the Mortgage Application and the lender's mortgage lifecycle.
+
+**Jimmy Vercellino**:
+The personal brand and leader of The Highly Motivated Vercellino Team.
+
+**PHXHomeLoan.com**:
+A Web Property of The Highly Motivated Vercellino Team. Its domain includes education, marketing, lead generation, nurture, and conversion before handing a Prospective Borrower to Luminate Bank for the Mortgage Application; its public display name is **PHX Home Loan**.
+
+**PHX Home Loan**:
+The public display name of PHXHomeLoan.com. It is not a separate organization.
+
+**Advisor**:
+A description of how Jimmy Vercellino and The Highly Motivated Vercellino Team guide Prospective Borrowers. It is not a formal identity or job title.
+
+**Team Member**:
+A person who belongs to The Highly Motivated Vercellino Team.
+
+### Website content
+
+**Web Property**:
+A website operated by The Highly Motivated Vercellino Team on its own domain. Separate Web Properties may serve different audiences without becoming separate organizations or brands.
+
+**Web Page**:
+Any public destination on PHXHomeLoan.com, including the homepage, blog index, Evergreen Pages, and Blog Posts.
+
+**Evergreen Page**:
+A Web Page with enduring content that is not the homepage, blog index, or a Blog Post.
+
+**Landing Page**:
+A Web Page for one defined Audience and Marketing Funnel, centered on one primary Conversion Point. Unlike an Evergreen Page, it does not serve several unrelated next steps.
+
+**Blog Post**:
+A dated educational item published on PHXHomeLoan.com with an author and category. **Post** is acceptable shorthand when the context is clear.
+_Avoid_: Article, Educational Content
+
+**Blog Post Author**:
+The person credited with creating a Blog Post. A Blog Post Author may also be a Team Member, but neither role implies the other.
+
+**Review**:
+Customer feedback independently published on a third-party platform, such as Google.
+
+**Testimonial**:
+A Customer statement supplied directly for use by PHXHomeLoan.com.
+
+### Audiences and lifecycle
+
+**Prospective Borrower**:
+A person exploring a home purchase, refinance, or mortgage options, whether or not they have contacted the team or begun a formal application.
+_Avoid_: Prospective Customer
+
+**Visitor**:
+A person while they are using PHXHomeLoan.com. This describes their current interaction with the website, not their lending relationship.
+
+**Audience**:
+A defined group of people with a shared mortgage need, situation, or acquisition source, targeted by Organic Content, Paid Media, or a Marketing Funnel.
+
+**Audience Segment**:
+A subgroup within an Audience, distinguished by more specific criteria so its Marketing and Nurture can address its needs more precisely. **Segment** is acceptable shorthand when the Audience is clear.
+
+**Primary Concern**:
+The concern an Audience Member, Visitor, or Lead identifies as most important within a Marketing Funnel. It determines their Audience Segment and shapes their Nurture.
+
+**Audience Member**:
+One person within an Audience, whether or not they have visited PHXHomeLoan.com.
+
+**Lead**:
+An Audience Member or Visitor who provides usable contact information through a Conversion Point, allowing follow-up by The Highly Motivated Vercellino Team.
+
+**Qualified Lead**:
+A Lead who schedules a Consultation with The Highly Motivated Vercellino Team, showing explicit intent to have a direct conversation.
+_Avoid_: MQL, SQL, Marketing Qualified Lead, Sales Qualified Lead
+
+**Handoff**:
+The process triggered when a Lead schedules a Consultation and their information is routed to The Highly Motivated Vercellino Team. The Handoff turns the Lead into a Qualified Lead; it is not a Lifecycle Stage.
+
+**Consultation**:
+The scheduled conversation where The Highly Motivated Vercellino Team understands a Qualified Lead's mortgage need and decides whether it is a real Opportunity. Booking creates the Qualified Lead; completing the Consultation can create the Opportunity.
+
+**Consultation Outcome**:
+The decision recorded after a completed Consultation: Opportunity, Preparation Needed, or Not Moving Forward.
+
+**Preparation Needed**:
+A Consultation Outcome used when a Qualified Lead has a real mortgage goal but must address a known obstacle before it becomes an Opportunity. The person remains a Qualified Lead.
+_Avoid_: Follow Up Later
+
+**Preparation Reason**:
+The broad reason a Qualified Lead needs more preparation, such as credit improvement, down-payment savings, timing, or employment stability. It excludes scores, balances, and detailed financial notes.
+
+**Long-Term Nurture**:
+Consented follow-up that helps a Qualified Lead address a Preparation Reason over time and return when ready for another Consultation.
+
+**Personal Follow-Up**:
+A planned direct contact from Jimmy Vercellino or another Team Member on a date chosen from the Consultation rather than an assumed schedule.
+
+**Not Moving Forward**:
+A Consultation Outcome used when The Highly Motivated Vercellino Team and the Qualified Lead will not continue toward an Opportunity.
+
+**Appointment**:
+The record of a scheduled Consultation, including when it will happen and its current status. PHXHomeLoan.com owns this record even when another service handles scheduling.
+
+**Scheduling Provider**:
+A service that handles Consultation availability, time zones, booking, and rescheduling. It does not own the Appointment or determine Marketing Automation.
+
+**Opportunity**:
+A confirmed mortgage need that The Highly Motivated Vercellino Team has agreed to pursue. An Opportunity may come from a Consultation with a Qualified Lead or from a returning Customer.
+
+**Customer**:
+A person who has closed at least one mortgage originated by The Highly Motivated Vercellino Team. A Customer can have multiple Opportunities over time without returning to an earlier Lifecycle Stage.
+
+**Advocate**:
+A Customer who actively recommends The Highly Motivated Vercellino Team through a referral, Review, or Testimonial.
+_Avoid_: Evangelist
+
+**Customer Lifecycle**:
+The shared sequence **Audience Member → Visitor → Lead → Qualified Lead → Opportunity → Customer → Advocate**. Marketing Funnels provide different routes through the same lifecycle.
+
+**Lifecycle Stage**:
+The furthest confirmed relationship milestone a person has reached in the Customer Lifecycle. Audience Member and Visitor roles can overlap with later stages without moving the Lifecycle Stage backward.
+
+### Marketing and conversion
+
+**Lead Magnet**:
+Free, useful content or an interactive experience explicitly offered in exchange for contact information. It may be delivered once or as a time-bounded series, such as a quiz result followed by a personalized action plan.
+
+**Marketing Funnel**:
+A planned route for one defined Audience that uses content, Landing Pages, Lead Magnets, Conversion Points, and Nurture to move an Audience Member toward becoming a Qualified Lead. PHXHomeLoan.com can support multiple Marketing Funnels.
+_Avoid_: Conversion Funnel
+
+**Marketing Funnel Version**:
+A published snapshot of a Marketing Funnel's quiz, Audience Segments, results, and promised Nurture Sequences. A Lead remains on the version accepted when they submitted the Lead Capture Form.
+
+**Nurture**:
+The ongoing delivery of useful, relevant follow-up that helps a Lead become a Qualified Lead. Content and ads shown before contact information is captured attract an Audience Member rather than nurture a known Lead.
+
+**Nurture Sequence**:
+An ordered series of messages that delivers Nurture to Leads in one Audience Segment. When the sequence is explicitly promised as part of a Lead Magnet, it belongs to that exchange rather than being an unrelated promotion.
+
+**Nurture Step**:
+One scheduled message or action within a Nurture Sequence.
+
+**Consent Record**:
+Evidence of what communication a person agreed to receive, including the exact promise, channel, timestamp, and form source.
+
+**Unsubscribe**:
+A person's request to stop all marketing email from PHXHomeLoan.com. It ends active Nurture Sequences but does not stop messages for a Consultation the person requested.
+
+**Lead Capture Form**:
+A form that collects usable contact information from an Audience Member or Visitor, turning them into a Lead.
+
+**Organic Content**:
+Unpaid videos, posts, and educational material published by Jimmy Vercellino to attract and help Audience Members.
+
+**Ad Creative**:
+Organic Content adapted into an advertisement.
+
+**Paid Media**:
+Purchased distribution of Ad Creative to a defined Audience.
+
+**Marketing Automation**:
+Automated processes that capture, route, follow up with, and measure Leads across Marketing Funnels. Nurture is one purpose of Marketing Automation.
+
+**Marketing Event**:
+An append-only record of something meaningful that happened in a Marketing Funnel, such as consent, message delivery, a reply, an Unsubscribe, or a Consultation booking.
+
+**Conversion Point**:
+An intentional opportunity for an Audience Member, Visitor, or Lead to complete a measurable action that moves them forward, such as submitting a form or quiz, requesting a Lead Magnet, calling, or following a tracked Apply Link.
+
+**Conversion**:
+The completed action or stage transition produced through a Conversion Point. Not every lifecycle transition requires a website Conversion Point.
+
+### Mortgage relationship
+
+**Mortgage Product**:
+A named mortgage offering or financing path presented on PHXHomeLoan.com, such as VA, FHA, Conventional, Jumbo, USDA, Construction-to-Permanent, ARM, or Refinance.
+_Avoid_: Loan Type, Loan Program, Mortgage Option
+
+**Contact Pathway**:
+A call or website form that lets a Prospective Borrower contact The Highly Motivated Vercellino Team.
+
+**Apply Link**:
+A link or button on PHXHomeLoan.com that leads to Luminate Bank's website and Mortgage Application.
+
+**Mortgage Application**:
+The formal application hosted and owned by Luminate Bank. It does not take place on PHXHomeLoan.com.
+
+**Phoenix Home Market**:
+The place where The Highly Motivated Vercellino Team and PHXHomeLoan.com are rooted. It is a brand identity, not a service boundary.
+
+**Nationwide Service**:
+The Highly Motivated Vercellino Team serves Prospective Borrowers throughout the United States without a regional boundary.

--- a/docs/adr/0002-own-appointments-behind-scheduling-adapters.md
+++ b/docs/adr/0002-own-appointments-behind-scheduling-adapters.md
@@ -1,0 +1,22 @@
+# ADR 0002: Own appointments behind scheduling adapters
+
+Date: 2026-08-19
+Status: Accepted
+
+## Context
+
+PHXHomeLoan.com needs a consistent Consultation flow across clients without making a Scheduling Provider the source of customer history. Jimmy currently uses Microsoft Bookings in Luminate Bank's Microsoft 365 tenant. Microsoft Bookings cannot send the booking events we need through webhooks or carry our contact ID through the booking, so an integration would need Power Automate or polling and would match records by email.
+
+## Decision
+
+- PostgreSQL owns every Appointment, including its contact, status, attribution, provider, and provider reference.
+- Marketing Automation reads Appointment records, never a provider API.
+- One provider adapter turns booking, rescheduling, and cancellation events into the same internal Appointment operations.
+- Cal.com is the first adapter and carries our contact ID in provider metadata.
+- A future Microsoft Bookings adapter may match by email, but that uncertainty stays inside the adapter.
+- Trigger.dev sends reminders. Scheduling Provider emails do not drive the Consultation flow.
+- Reschedule and cancellation links start from our Appointment ID and resolve through the active adapter.
+
+## Open question
+
+Ask Jimmy whether Luminate Bank requires loan originators to use bank-approved scheduling or communication tools for supervision, recordkeeping, or data handling. If it does, add the Microsoft Bookings adapter without changing downstream Appointment or Marketing Automation behavior.

--- a/docs/adr/0003-share-nurture-behavior-between-demo-and-production.md
+++ b/docs/adr/0003-share-nurture-behavior-between-demo-and-production.md
@@ -1,0 +1,18 @@
+# ADR 0003: Share nurture behavior between demo and production
+
+Date: 2026-08-19
+Status: Accepted
+
+## Context
+
+The Tech Demo must show a fourteen-day Nurture Sequence during one presentation. A separate fast demo would prove little and would drift from the product behavior we intend to ship.
+
+## Decision
+
+- Demo and production share message content, stop rules, delivery, and event recording.
+- A waiting interface separates two adapters. Production waits until the scheduled date. The Tech Demo waits for a Trigger.dev token that a `Run now` control completes.
+- `Run now` advances one Lead's next Nurture Step. It never changes the system clock.
+- Next.js verifies that the request belongs to a demo journey before it completes the server-side wait token.
+- After resuming, Trigger.dev rechecks whether the Lead booked, replied, or unsubscribed before delivery.
+- PostgreSQL permits only one delivery event for each Lead and Nurture Step. Button state is only a user-interface safeguard.
+- The Tech Demo uses a Twilio trial account to send real SMS to approved test numbers. Automated tests use Twilio test credentials and send nothing.

--- a/docs/adr/0004-version-funnel-content-at-consent.md
+++ b/docs/adr/0004-version-funnel-content-at-consent.md
@@ -1,0 +1,16 @@
+# ADR 0004: Version funnel content at consent
+
+Date: 2026-08-20
+Status: Accepted
+
+## Context
+
+Editors need to improve quiz and email content without changing what an active Lead agreed to receive. Reading the latest Sanity document at every Nurture Step would let a publish silently alter an active action plan and weaken the Consent Record.
+
+## Decision
+
+- Sanity owns published Marketing Funnel content. PostgreSQL owns customer activity and Consent Records.
+- One Marketing Funnel editing area contains its quiz, Audience Segments, result guidance, and Nurture Sequences until real reuse justifies separate documents.
+- Each Audience Segment has a permanent internal identity and an editable public name.
+- A Lead starts one published Marketing Funnel Version and remains on it through the full Nurture Sequence.
+- Draft edits affect nobody. Newly published content applies only to later submissions.

--- a/docs/adr/0005-drive-automation-from-owned-marketing-events.md
+++ b/docs/adr/0005-drive-automation-from-owned-marketing-events.md
@@ -1,0 +1,18 @@
+# ADR 0005: Drive automation from owned marketing events
+
+Date: 2026-08-20
+Status: Accepted
+
+## Context
+
+Resend, Twilio, Trigger.dev, and Scheduling Providers describe the same customer actions with different event names and payloads. Letting those formats drive Marketing Automation would spread provider assumptions through the product and make customer history depend on vendor retention.
+
+## Decision
+
+- PostgreSQL stores current customer state and an append-only Marketing Event history.
+- Each provider adapter verifies, deduplicates, and translates incoming events before anything downstream reacts.
+- Marketing Automation reads owned records and Marketing Events. It never asks a provider for customer truth.
+- Provider event IDs, receipt time, processing result, and a limited diagnostic payload remain linked to the resulting Marketing Event.
+- Message status distinguishes scheduled, attempted, accepted by provider, delivered, and failed.
+- Email opens may support reporting but never change Lifecycle Stage, Audience Segment, or Nurture.
+- Attribution preserves the Lead's original source and the source connected to each later Conversion.

--- a/docs/adr/0006-use-neon-for-operational-postgres.md
+++ b/docs/adr/0006-use-neon-for-operational-postgres.md
@@ -1,0 +1,15 @@
+# ADR 0006: Use Neon for operational PostgreSQL
+
+Date: 2026-08-20
+Status: Accepted
+
+## Context
+
+The Tech Demo needs plain PostgreSQL, Drizzle support, isolated preview data, and a clean Vercel deployment. Supabase adds authentication, storage, realtime, and data APIs that this product does not need.
+
+## Decision
+
+- Use Neon for the Tech Demo and first real product version.
+- Keep Drizzle migrations in the repository and use ordinary PostgreSQL features so another host can replace Neon.
+- Keep Neon-specific code outside business modules.
+- Revisit region and contractual requirements before storing real customer data.

--- a/docs/adr/0007-use-trigger-dev-cloud-initially.md
+++ b/docs/adr/0007-use-trigger-dev-cloud-initially.md
@@ -1,0 +1,16 @@
+# ADR 0007: Use Trigger.dev Cloud initially
+
+Date: 2026-08-20
+Status: Accepted
+
+## Context
+
+The product needs long waits, retries, and the Tech Demo's externally completed wait tokens. Trigger.dev Cloud checkpoints waiting runs, while self-hosting would make us operate its database, Redis, workers, storage, backups, and monitoring.
+
+## Decision
+
+- Use Trigger.dev Cloud Free for the Tech Demo and Cloud for the first real product version.
+- Send opaque Contact, Appointment, and Nurture IDs to Trigger.dev. Do not put personal data in task payloads, tags, or logs.
+- Keep durable customer history and idempotency records in PostgreSQL rather than Trigger.dev run history.
+- Upgrade only when staging, concurrency, or longer diagnosis history requires it.
+- Revisit hosting and data location after confirming the client's bank-tooling and privacy requirements.

--- a/docs/adr/0008-use-clerk-for-application-login.md
+++ b/docs/adr/0008-use-clerk-for-application-login.md
@@ -1,0 +1,16 @@
+# ADR 0008: Use Clerk for application login
+
+Date: 2026-08-20
+Status: Accepted
+
+## Context
+
+PHXHomeLoan.com needs real login for its private team area. Application login and Microsoft calendar authorization solve different problems and must remain separate.
+
+## Decision
+
+- Use Clerk for application login. Use Microsoft Graph OAuth separately for calendar access.
+- Use one Clerk Organization for The Highly Motivated Vercellino Team with Clerk's built-in administrator and member roles.
+- The PHXHomeLoan.com database grants access using Clerk user and Organization IDs.
+- Keep other Web Properties, satellite domains, cross-property login, and cross-client administration out of scope.
+- Reconsider WorkOS only when a paying client requires enterprise SSO, directory sync, or bank-controlled employee access.

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -66,3 +66,4 @@ plugins/impeccable-live.client.ts
 app/plugins/impeccable-live.client.ts
 src/plugins/impeccable-live.client.ts
 # impeccable-live-ignore-end
+.env*

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -67,3 +67,7 @@ app/plugins/impeccable-live.client.ts
 src/plugins/impeccable-live.client.ts
 # impeccable-live-ignore-end
 .env*
+!.env.example
+!.env*.example
+!.env.template
+!.env*.template

--- a/frontend/app/(main)/[...slug]/page.test.ts
+++ b/frontend/app/(main)/[...slug]/page.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sanityFetchMetadata = vi.hoisted(() => vi.fn());
+const notFound = vi.hoisted(() =>
+  vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+);
+
+vi.mock("@/components/root-content", () => ({ RootContentView: vi.fn() }));
+vi.mock("@/components/post-sidebar/model", () => ({
+  getBlogPostSidebar: vi.fn(),
+}));
+vi.mock("@/lib/routes", () => ({ contentPath: vi.fn() }));
+vi.mock("@/sanity/lib/fetch", () => ({
+  fetchBlogPostSettings: vi.fn(),
+  fetchSanityPageBySlug: vi.fn(),
+  fetchSanityPostBySlug: vi.fn(),
+  PAGES_SLUGS_QUERY: "pages",
+  POSTS_SLUGS_QUERY: "posts",
+}));
+vi.mock("@/sanity/lib/live", () => ({
+  getDynamicFetchOptions: vi.fn(),
+  sanityFetchMetadata,
+  sanityFetchStaticParams: vi.fn(),
+}));
+vi.mock("@/sanity/lib/metadata", () => ({
+  generatePageMetadata: vi.fn(),
+}));
+vi.mock("@/sanity/queries/page", () => ({ PAGE_QUERY: "page" }));
+vi.mock("@/sanity/queries/post", () => ({ POST_QUERY: "post" }));
+vi.mock("next/headers", () => ({ draftMode: vi.fn() }));
+vi.mock("next/navigation", () => ({ notFound }));
+
+import { generateMetadata } from "./page";
+
+describe("root content metadata", () => {
+  beforeEach(() => {
+    sanityFetchMetadata.mockReset();
+    notFound.mockClear();
+  });
+
+  it("does not turn a draft-only route into a 404", async () => {
+    sanityFetchMetadata.mockResolvedValue({ data: null });
+
+    await expect(
+      generateMetadata({ params: Promise.resolve({ slug: ["draft-post"] }) }),
+    ).resolves.toEqual({});
+    expect(notFound).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/(main)/[...slug]/page.tsx
+++ b/frontend/app/(main)/[...slug]/page.tsx
@@ -79,7 +79,9 @@ export async function generateMetadata(props: {
     }) as Promise<{ data: POST_QUERY_RESULT }>,
   ]);
   const content = resolveRootContent(page, post, slugPath);
-  if (!content) notFound();
+  // The page renderer owns 404s. Metadata only sees published content, so a
+  // 404 here would prevent draft-only routes from reaching Presentation.
+  if (!content) return {};
 
   return generatePageMetadata({ page: content, path: contentPath(slugPath) });
 }

--- a/studio/schemas/blocks/advisor-cta.ts
+++ b/studio/schemas/blocks/advisor-cta.ts
@@ -30,7 +30,17 @@ export default defineType({
       name: "richText",
       title: "Description",
       type: "array",
-      of: [defineArrayMember({ type: "block" })],
+      of: [
+        defineArrayMember({
+          type: "block",
+          marks: {
+            decorators: [
+              { title: "Strong", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
+          },
+        }),
+      ],
     }),
     defineField({
       name: "buttons",

--- a/studio/schemas/blocks/editorial-chapter.ts
+++ b/studio/schemas/blocks/editorial-chapter.ts
@@ -161,6 +161,12 @@ export default defineType({
           type: "block",
           styles: [{ title: "Normal", value: "normal" }],
           lists: [],
+          marks: {
+            decorators: [
+              { title: "Strong", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
+          },
         }),
       ],
       validation: (rule) => rule.required(),

--- a/studio/schemas/blocks/home-hero.ts
+++ b/studio/schemas/blocks/home-hero.ts
@@ -40,7 +40,17 @@ export default defineType({
       name: "richText",
       title: "Supporting Message",
       type: "array",
-      of: [defineArrayMember({ type: "block" })],
+      of: [
+        defineArrayMember({
+          type: "block",
+          marks: {
+            decorators: [
+              { title: "Strong", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
+          },
+        }),
+      ],
     }),
     defineField({
       name: "buttons",

--- a/studio/schemas/blocks/person-cta.ts
+++ b/studio/schemas/blocks/person-cta.ts
@@ -34,7 +34,17 @@ export default defineType({
       title: "Description",
       type: "array",
       description: "The supporting message shown below the heading",
-      of: [defineArrayMember({ type: "block" })],
+      of: [
+        defineArrayMember({
+          type: "block",
+          marks: {
+            decorators: [
+              { title: "Strong", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
+          },
+        }),
+      ],
       validation: (rule) => rule.required(),
     }),
     defineField({

--- a/studio/schemas/blocks/shared/custom-url.ts
+++ b/studio/schemas/blocks/shared/custom-url.ts
@@ -61,7 +61,7 @@ export default defineType({
     defineField({
       name: "type",
       type: "string",
-      initialValue: "external",
+      initialValue: "internal",
       options: {
         layout: "radio",
         list: [

--- a/studio/schemas/blocks/shared/rich-text-content.ts
+++ b/studio/schemas/blocks/shared/rich-text-content.ts
@@ -36,7 +36,6 @@ export default defineType({
         decorators: [
           { title: "Strong", value: "strong" },
           { title: "Emphasis", value: "em" },
-          { title: "Code", value: "code" },
         ],
       },
     }),

--- a/studio/schemas/blocks/team-members.ts
+++ b/studio/schemas/blocks/team-members.ts
@@ -36,7 +36,17 @@ export default defineType({
       title: "Intro Text",
       description:
         "Optional introductory copy shown before the team member profiles.",
-      of: [defineArrayMember({ type: "block" })],
+      of: [
+        defineArrayMember({
+          type: "block",
+          marks: {
+            decorators: [
+              { title: "Strong", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
+          },
+        }),
+      ],
     }),
     defineField({
       name: "members",

--- a/studio/schemas/blocks/video-feature.ts
+++ b/studio/schemas/blocks/video-feature.ts
@@ -33,7 +33,17 @@ export default defineType({
       title: "Supporting Message",
       type: "array",
       description: "The supporting message shown beside the featured video",
-      of: [defineArrayMember({ type: "block" })],
+      of: [
+        defineArrayMember({
+          type: "block",
+          marks: {
+            decorators: [
+              { title: "Strong", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
+          },
+        }),
+      ],
     }),
     defineField({
       name: "buttons",

--- a/studio/schemas/documents/post.ts
+++ b/studio/schemas/documents/post.ts
@@ -57,7 +57,6 @@ export default defineType({
             decorators: [
               { title: "Strong", value: "strong" },
               { title: "Emphasis", value: "em" },
-              { title: "Code", value: "code" },
             ],
             annotations: [],
           },

--- a/studio/schemas/documents/team-member.ts
+++ b/studio/schemas/documents/team-member.ts
@@ -75,7 +75,17 @@ export default defineType({
       title: "Bio",
       description:
         "A short biography describing this team member's responsibilities and expertise.",
-      of: [defineArrayMember({ type: "block" })],
+      of: [
+        defineArrayMember({
+          type: "block",
+          marks: {
+            decorators: [
+              { title: "Strong", value: "strong" },
+              { title: "Emphasis", value: "em" },
+            ],
+          },
+        }),
+      ],
     }),
     defineField({
       name: "sortOrder",


### PR DESCRIPTION
Draft-only routes could return a 404 while Studio generated metadata. Rich-text links also opened with External selected and exposed a Code style the site does not need.

This keeps metadata from blocking draft routes, defaults new destinations to Internal, and removes Code from every Portable Text field. The branch also records the current domain glossary and automation ADRs and ignores local environment files.

Tests were not rerun for the final schema cleanup. A focused draft-route test is included.

Prepared with GPT-5 in OpenAI Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Draft-only and unavailable pages now handle metadata gracefully while preserving proper 404 behavior.

- **Content Authoring**
  - Rich-text editors now provide consistent bold and italic formatting across content blocks.
  - Code formatting has been removed where it is not supported.
  - New internal links default to internal destinations.

- **Documentation**
  - Added guidance for appointments, marketing automation, funnel versioning, event handling, hosting, authentication, and nurture workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->