### PR TITLE
fix(seo): address title migration edge cases

### DIFF
--- a/frontend/app/api/og/page/[...path]/route.test.ts
+++ b/frontend/app/api/og/page/[...path]/route.test.ts
@@ -72,6 +72,17 @@ describe("page OG image route", () => {
     );
   });
 
+  it("keeps the SEO override out of the visible card headline", async () => {
+    sanityFetchMetadata.mockResolvedValueOnce({
+      data: {
+        overrideTitle: "Home | The Highly Motivated Vercellino Team",
+        title,
+      },
+    });
+
+    expect((await get(signedUrl())).status).toBe(200);
+  });
+
   it("rejects stale, missing, or unpublished page content", async () => {
     sanityFetchMetadata.mockResolvedValueOnce({ data: { title: "Changed" } });
     expect((await get(signedUrl())).status).toBe(404);

--- a/frontend/app/api/og/page/[...path]/route.tsx
+++ b/frontend/app/api/og/page/[...path]/route.tsx
@@ -54,12 +54,12 @@ async function fetchTitle(
     })) as { data: { overrideTitle?: string | null; title?: string | null } | null };
     if (!data) return null;
 
-    // Mirror generatePageMetadata's fallback chain (down to the site name) so
-    // every signed homepage URL renders instead of 404ing on missing titles.
-    return resolveSeoTitle({
-      fallbackTitle: data.title,
-      overrideTitle: data.overrideTitle,
-    }).pageTitle;
+    // The card headline follows the visible content title. The SEO override
+    // stays in metadata and image alt text.
+    return getPageOgImageTitle(
+      data.title ||
+        resolveSeoTitle({ overrideTitle: data.overrideTitle }).pageTitle,
+    );
   }
 
   const query =

--- a/frontend/lib/seo-title.test.ts
+++ b/frontend/lib/seo-title.test.ts
@@ -40,7 +40,7 @@ describe("resolveSeoTitle", () => {
     });
   });
 
-  it("uses any title containing a pipe as the complete title", () => {
+  it("uses any override containing a pipe as the complete title", () => {
     expect(
       resolveSeoTitle({
         fallbackTitle: "Fallback",
@@ -65,6 +65,25 @@ describe("resolveSeoTitle", () => {
         overrideTitle: "FHA Loans | Phoenix Mortgage Lenders",
       }).finalTitle,
     ).toBe("FHA Loans | Phoenix Mortgage Lenders");
+  });
+
+  it("does not treat a pipe in the content title as an override", () => {
+    expect(
+      resolveSeoTitle({
+        fallbackTitle: "Fixed vs. Adjustable | Which Is Right?",
+      }).finalTitle,
+    ).toBe(
+      "Fixed vs. Adjustable | Which Is Right? | The Vercellino Team",
+    );
+  });
+
+  it("falls back when cleaning an override leaves no page title", () => {
+    expect(
+      resolveSeoTitle({
+        fallbackTitle: "Mortgage Guidance",
+        overrideTitle: "- PHX Home Loan",
+      }).finalTitle,
+    ).toBe("Mortgage Guidance | The Vercellino Team");
   });
 
   it("returns an absolute title when only the site name remains", () => {

--- a/frontend/lib/seo-title.test.ts
+++ b/frontend/lib/seo-title.test.ts
@@ -116,6 +116,17 @@ describe("resolveSeoTitle", () => {
 });
 
 describe("getSeoTitleWarnings", () => {
+  it("warns when a non-pipe override contains a legacy suffix", () => {
+    expect(
+      getSeoTitleWarnings({
+        fallbackTitle: "Fallback",
+        overrideTitle: "FHA Loans - PHX Home Loan",
+      }),
+    ).toContain(
+      "Remove the manual legacy suffix; the default suffix is automatic.",
+    );
+  });
+
   it("warns without rejecting manual suffixes, repetition, or length", () => {
     const warnings = getSeoTitleWarnings({
       fallbackTitle: "Fallback",

--- a/frontend/sanity/lib/metadata.test.ts
+++ b/frontend/sanity/lib/metadata.test.ts
@@ -129,7 +129,7 @@ describe("generatePageMetadata", () => {
       title: "About | Phoenix Mortgage Lenders",
       type: "website",
       images: [
-        { width: 1200, height: 630, alt: "About | The Vercellino Team" },
+        { width: 1200, height: 630, alt: "About | Phoenix Mortgage Lenders" },
       ],
     });
     expect(url.pathname).toBe("/api/og/page/page/about");
@@ -178,6 +178,9 @@ describe("generatePageMetadata", () => {
       "Phoenix Mortgage Lender | PHX Home Loan",
     );
     expect(metadata.twitter.title).toBe(
+      "Phoenix Mortgage Lender | PHX Home Loan",
+    );
+    expect(metadata.openGraph.images[0].alt).toBe(
       "Phoenix Mortgage Lender | PHX Home Loan",
     );
   });

--- a/frontend/sanity/lib/metadata.test.ts
+++ b/frontend/sanity/lib/metadata.test.ts
@@ -193,6 +193,7 @@ describe("generateBlogIndexMetadata", () => {
 
     expect(metadata.title).toEqual({ absolute: title });
     expect(metadata.openGraph.title).toBe(title);
+    expect(metadata.openGraph.images[0].alt).toBe(title);
     expect(metadata.twitter.title).toBe(title);
   });
 });
@@ -206,6 +207,7 @@ describe("generateCategoryMetadata", () => {
 
     expect(metadata.title).toEqual({ absolute: pageTitle });
     expect(metadata.openGraph.title).toBe(pageTitle);
+    expect(metadata.openGraph.images[0].alt).toBe(pageTitle);
     expect(metadata.twitter.title).toBe(pageTitle);
   });
 });

--- a/frontend/sanity/lib/metadata.ts
+++ b/frontend/sanity/lib/metadata.ts
@@ -176,6 +176,7 @@ export function generateBlogIndexMetadata({
       title: cardTitle,
     }),
     cardTitle,
+    pageTitleResolution.finalTitle,
   );
 
   return {
@@ -228,6 +229,7 @@ export function generateCategoryMetadata({
             title: cardTitle,
           }),
           cardTitle,
+          pageTitleResolution.finalTitle,
         )
       : fallbackSharingImage();
   const isIndexable = isIndexableCategory({

--- a/frontend/sanity/lib/metadata.ts
+++ b/frontend/sanity/lib/metadata.ts
@@ -23,12 +23,12 @@ const isProduction = process.env.NEXT_PUBLIC_SITE_ENV === "production";
 
 const siteOrigin = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
 
-function sharingImage(url: string, title: string) {
+function sharingImage(url: string, title: string, alt = `${title}${TITLE_SUFFIX}`) {
   return {
     url,
     width: 1200,
     height: 630,
-    alt: `${title}${TITLE_SUFFIX}`,
+    alt,
   };
 }
 
@@ -56,6 +56,9 @@ function resolveArchiveTitles({
   });
   const pageTitleResolution = resolveSeoTitle({
     fallbackTitle: getBlogPageTitle(baseTitleResolution.pageTitle, page),
+    ...(overrideTitle?.includes("|")
+      ? { overrideTitle: getBlogPageTitle(baseTitleResolution.finalTitle, page) }
+      : {}),
   });
   const cardTitle = getBlogPageTitle(
     getPageOgImageTitle(contentTitle || overrideTitle || fallbackTitle),
@@ -93,7 +96,7 @@ export function generatePageMetadata({
       : null;
   const rawPageTitle =
     isHomepage
-      ? seoTitle.pageTitle
+      ? page.title || seoTitle.pageTitle
       : page?._type === "page"
         ? page.title || page.meta?.title
         : undefined;
@@ -115,10 +118,12 @@ export function generatePageMetadata({
           title: pageTitle,
         })
       : null;
+  // The generated card uses the visible content title. Its alt text uses the
+  // final social title, including any complete suffix supplied by the editor.
   const image = postImage && postTitle
     ? sharingImage(postImage, postTitle)
     : pageImage && pageTitle
-      ? sharingImage(pageImage, pageTitle)
+      ? sharingImage(pageImage, pageTitle, seoTitle.finalTitle)
       : fallbackSharingImage();
 
   return {

--- a/shared/seo-title.ts
+++ b/shared/seo-title.ts
@@ -51,14 +51,13 @@ export function resolveSeoTitle({
   isHomepage?: boolean;
   overrideTitle?: string | null;
 }) {
-  const selectedTitle =
-    normalizeSeoTitle(overrideTitle) ||
-    normalizeSeoTitle(fallbackTitle) ||
-    SITE_NAME;
-  const hasManualSuffix = selectedTitle.includes("|");
+  const normalizedOverride = normalizeSeoTitle(overrideTitle);
+  const hasManualSuffix = normalizedOverride.includes("|");
   const pageTitle = hasManualSuffix
-    ? selectedTitle
-    : stripLegacySeoTitleSuffix(selectedTitle);
+    ? normalizedOverride
+    : stripLegacySeoTitleSuffix(normalizedOverride) ||
+      stripLegacySeoTitleSuffix(fallbackTitle) ||
+      SITE_NAME;
   const finalTitle = hasManualSuffix
     ? pageTitle
     : pageTitle.toLowerCase() === SITE_NAME.toLowerCase()

--- a/studio/migrations/migrate-page-seo-metadata/index.test.mjs
+++ b/studio/migrations/migrate-page-seo-metadata/index.test.mjs
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { planPageSeoMigration } from "./index.ts";
+import {
+  buildPageSeoOperations,
+  PAGE_SEO_MIGRATION_FILTER,
+  planPageSeoMigration,
+} from "./index.ts";
 
 test("preserves the legacy SEO values exactly", () => {
   const plan = planPageSeoMigration({
@@ -53,4 +57,31 @@ test("rejects malformed source or destination fields before writes", () => {
   assert.match(plan.issues[0], /meta must be an object/);
   assert.match(plan.issues[1], /seoTitle must be a string/);
   assert.match(plan.issues[2], /seoDescription must be a string/);
+});
+
+test("creates meta before setting nested fields", () => {
+  assert.deepEqual(
+    buildPageSeoOperations({
+      title: "Legacy title",
+      description: "Legacy description.",
+      issues: [],
+    }),
+    [
+      { op: { type: "setIfMissing", value: {} }, path: ["meta"] },
+      { op: { type: "set", value: "Legacy title" }, path: ["meta", "title"] },
+      {
+        op: { type: "set", value: "Legacy description." },
+        path: ["meta", "description"],
+      },
+      { op: { type: "unset" }, path: ["seoTitle"] },
+      { op: { type: "unset" }, path: ["seoDescription"] },
+    ],
+  );
+});
+
+test("includes release-version pages in the migration filter", () => {
+  assert.equal(
+    PAGE_SEO_MIGRATION_FILTER,
+    "defined(seoTitle) || defined(seoDescription)",
+  );
 });

--- a/studio/migrations/migrate-page-seo-metadata/index.ts
+++ b/studio/migrations/migrate-page-seo-metadata/index.ts
@@ -1,4 +1,11 @@
-import { at, defineMigration, patch, set, unset } from "sanity/migrate";
+import {
+  at,
+  defineMigration,
+  patch,
+  set,
+  setIfMissing,
+  unset,
+} from "sanity/migrate";
 import type { SanityDocument } from "sanity";
 
 type LegacyPageSeoDocument = SanityDocument & {
@@ -12,6 +19,9 @@ export type PageSeoMigrationPlan = {
   issues: string[];
   title?: string;
 };
+
+export const PAGE_SEO_MIGRATION_FILTER =
+  "defined(seoTitle) || defined(seoDescription)";
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -49,11 +59,24 @@ export function planPageSeoMigration(
   };
 }
 
+export function buildPageSeoOperations(plan: PageSeoMigrationPlan) {
+  return [
+    at("meta", setIfMissing({})),
+    ...(plan.title !== undefined
+      ? [at("meta.title", set(plan.title))]
+      : []),
+    ...(plan.description !== undefined
+      ? [at("meta.description", set(plan.description))]
+      : []),
+    at("seoTitle", unset()),
+    at("seoDescription", unset()),
+  ];
+}
+
 export default defineMigration({
   title: "Move legacy page SEO fields into canonical metadata",
   documentTypes: ["page"],
-  filter:
-    '!(_id in path("versions.**")) && (defined(seoTitle) || defined(seoDescription))',
+  filter: PAGE_SEO_MIGRATION_FILTER,
   async *migrate(documents) {
     const plans: Array<{
       document: LegacyPageSeoDocument;
@@ -85,18 +108,9 @@ export default defineMigration({
     );
 
     for (const { document, plan } of plans) {
-      const operations = [
-        ...(plan.title !== undefined
-          ? [at("meta.title", set(plan.title))]
-          : []),
-        ...(plan.description !== undefined
-          ? [at("meta.description", set(plan.description))]
-          : []),
-        at("seoTitle", unset()),
-        at("seoDescription", unset()),
-      ];
-
-      yield patch(document._id, operations, { ifRevision: document._rev });
+      yield patch(document._id, buildPageSeoOperations(plan), {
+        ifRevision: document._rev,
+      });
     }
   },
 });


### PR DESCRIPTION
The original SEO title work landed on `main` while this PR was under review. The review found edge cases that still needed fixes.

This limits the pipe rule to SEO overrides, keeps social-image alt text consistent, preserves fallback titles after legacy cleanup, creates missing metadata objects during migration, and includes release versions.

Tests: frontend suite, focused migration tests, lint, frontend typecheck, Studio typecheck. The root suite still has the unrelated redirect-policy failure already present on `main`.

Built with Codex desktop using GPT-5.
