### PR TITLE
ci: add release gate

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,69 @@
+name: Release gate
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: release-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  release-gate:
+    name: Release gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
+      NEXT_PUBLIC_STUDIO_URL: ${{ vars.NEXT_PUBLIC_STUDIO_URL }}
+      NEXT_PUBLIC_SITE_ENV: production
+      NEXT_PUBLIC_SANITY_API_VERSION: ${{ vars.NEXT_PUBLIC_SANITY_API_VERSION }}
+      NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ vars.NEXT_PUBLIC_SANITY_PROJECT_ID }}
+      NEXT_PUBLIC_SANITY_DATASET: ${{ vars.NEXT_PUBLIC_SANITY_DATASET }}
+      OG_IMAGE_SECRET: ci-only-og-image-secret
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.10.0
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Run unit tests
+        run: pnpm test
+
+      - name: Build production frontend
+        run: pnpm --dir frontend build
+
+      - name: Install smoke-test browser
+        run: pnpm --dir frontend exec playwright install --with-deps chrome
+
+      - name: Run browser smoke tests
+        env:
+          PLAYWRIGHT_REUSE_BUILD: "1"
+        run: pnpm test:smoke

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -35,7 +35,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 11.10.0
           run_install: false
 
       - name: Set up Node.js

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -27,22 +27,18 @@ jobs:
       NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ vars.NEXT_PUBLIC_SANITY_PROJECT_ID }}
       NEXT_PUBLIC_SANITY_DATASET: ${{ vars.NEXT_PUBLIC_SANITY_DATASET }}
       OG_IMAGE_SECRET: ci-only-og-image-secret
+      SANITY_API_READ_TOKEN: ${{ secrets.SANITY_API_READ_TOKEN }}
 
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
+      - name: Set up pnpm and Node.js
+        uses: pnpm/setup@v2
         with:
-          run_install: false
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+          runtime: node@24
+          cache: true
+          install: false
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -52,8 +52,6 @@ jobs:
         run: pnpm test
 
       - name: Build production frontend
-        env:
-          SANITY_API_READ_TOKEN: ${{ secrets.SANITY_API_READ_TOKEN }}
         run: pnpm --dir frontend build
 
       - name: Install smoke-test browser

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -27,7 +27,6 @@ jobs:
       NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ vars.NEXT_PUBLIC_SANITY_PROJECT_ID }}
       NEXT_PUBLIC_SANITY_DATASET: ${{ vars.NEXT_PUBLIC_SANITY_DATASET }}
       OG_IMAGE_SECRET: ci-only-og-image-secret
-      SANITY_API_READ_TOKEN: ${{ secrets.SANITY_API_READ_TOKEN }}
 
     steps:
       - name: Check out repository
@@ -53,6 +52,8 @@ jobs:
         run: pnpm test
 
       - name: Build production frontend
+        env:
+          SANITY_API_READ_TOKEN: ${{ secrets.SANITY_API_READ_TOKEN }}
         run: pnpm --dir frontend build
 
       - name: Install smoke-test browser
@@ -61,4 +62,5 @@ jobs:
       - name: Run browser smoke tests
         env:
           PLAYWRIGHT_REUSE_BUILD: "1"
+          SANITY_API_READ_TOKEN: ${{ secrets.SANITY_API_READ_TOKEN }}
         run: pnpm test:smoke

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -31,10 +31,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Set up pnpm and Node.js
-        uses: pnpm/setup@v2
+        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2
         with:
           runtime: node@24
           cache: true

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -62,5 +62,4 @@ jobs:
       - name: Run browser smoke tests
         env:
           PLAYWRIGHT_REUSE_BUILD: "1"
-          SANITY_API_READ_TOKEN: ${{ secrets.SANITY_API_READ_TOKEN }}
         run: pnpm test:smoke

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
 
       - name: Set up pnpm and Node.js
         uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -16,6 +16,7 @@ NEXT_PUBLIC_SANITY_PROJECT_ID=your-project-id
 NEXT_PUBLIC_SANITY_DATASET=development
 # Required in every environment. Signs OG image URLs so callers cannot create arbitrary render work.
 OG_IMAGE_SECRET=generate-a-long-random-value
+# Required for Sanity draft previews. Published content is public.
 SANITY_API_READ_TOKEN=your-token
 
 # shadcnblocks.com registry key, used by the shadcn CLI/MCP to install blocks

--- a/frontend/app/(main)/contact/thanks/page.tsx
+++ b/frontend/app/(main)/contact/thanks/page.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/components/ui/button";
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  robots: "noindex, nofollow",
+  title: "Message sent",
+};
+
+export default function ContactThanksPage() {
+  return (
+    <section className="section-pad surface-white">
+      <div className="container max-w-3xl">
+        <p className="mb-3.5 typo-eyebrow text-primary">Message sent</p>
+        <h1 className="text-balance typo-page-heading text-foreground">
+          Thanks for reaching out.
+        </h1>
+        <p className="mt-5 max-w-xl text-pretty typo-lead text-muted-foreground">
+          Jimmy and his team typically respond the same business day.
+        </p>
+        <Button asChild className="mt-8">
+          <Link href="/contact/">Back to contact</Link>
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/actions/submit-contact-form.test.ts
+++ b/frontend/app/actions/submit-contact-form.test.ts
@@ -1,0 +1,82 @@
+import {
+  initialContactFormState,
+  submitContactForm,
+} from "@/app/actions/submit-contact-form";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { redirectMock } = vi.hoisted(() => ({
+  redirectMock: vi.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+}));
+
+vi.mock("next/navigation", () => ({ redirect: redirectMock }));
+
+function validFormData() {
+  const formData = new FormData();
+  formData.set("email", "ovi@example.com");
+  formData.set("message", "I would like to talk about a home loan.");
+  formData.set("name", "Ovi");
+  formData.set("phone", "480-555-0100");
+  return formData;
+}
+
+describe("submitContactForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("submits valid form data to Formspark and redirects", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      submitContactForm(initialContactFormState, validFormData()),
+    ).rejects.toThrow("NEXT_REDIRECT");
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://submit-form.com/a0or7TBtU",
+      expect.objectContaining({
+        body: JSON.stringify({
+          email: "ovi@example.com",
+          message: "I would like to talk about a home loan.",
+          name: "Ovi",
+          phone: "480-555-0100",
+        }),
+        method: "POST",
+      }),
+    );
+    expect(redirectMock).toHaveBeenCalledWith("/contact/thanks/");
+  });
+
+  it("rejects invalid form data before contacting Formspark", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await submitContactForm(
+      initialContactFormState,
+      new FormData(),
+    );
+
+    expect(result.error).toBe("Please check the form and try again.");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("reports a Formspark delivery failure", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response(null, { status: 500 })),
+    );
+
+    const result = await submitContactForm(
+      initialContactFormState,
+      validFormData(),
+    );
+
+    expect(result.error).toBe(
+      "Your message could not be sent. Please try again.",
+    );
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/app/actions/submit-contact-form.test.ts
+++ b/frontend/app/actions/submit-contact-form.test.ts
@@ -1,7 +1,4 @@
-import {
-  initialContactFormState,
-  submitContactForm,
-} from "@/app/actions/submit-contact-form";
+import { submitContactForm } from "@/app/actions/submit-contact-form";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const { redirectMock } = vi.hoisted(() => ({
@@ -20,6 +17,8 @@ function validFormData() {
   formData.set("phone", "480-555-0100");
   return formData;
 }
+
+const initialContactFormState = { error: null };
 
 describe("submitContactForm", () => {
   beforeEach(() => {
@@ -74,6 +73,33 @@ describe("submitContactForm", () => {
       validFormData(),
     );
 
+    expect(result.error).toBe(
+      "Your message could not be sent. Please try again.",
+    );
+    expect(redirectMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts a stalled Formspark request", async () => {
+    const timeoutError = new DOMException("Timed out", "TimeoutError");
+    const timeoutSignal = AbortSignal.abort(timeoutError);
+    const timeoutSpy = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockReturnValue(timeoutSignal);
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(timeoutSignal.reason);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await submitContactForm(
+      initialContactFormState,
+      validFormData(),
+    );
+
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://submit-form.com/a0or7TBtU",
+      expect.objectContaining({ signal: timeoutSignal }),
+    );
     expect(result.error).toBe(
       "Your message could not be sent. Please try again.",
     );

--- a/frontend/app/actions/submit-contact-form.ts
+++ b/frontend/app/actions/submit-contact-form.ts
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import { z } from "zod";
 
 const FORMSPARK_ACTION_URL = "https://submit-form.com/a0or7TBtU";
+const FORMSPARK_TIMEOUT_MS = 10_000;
 
 const contactSubmissionSchema = z.object({
   email: z.email().max(320),
@@ -14,10 +15,6 @@ const contactSubmissionSchema = z.object({
 
 export type ContactFormState = {
   error: string | null;
-};
-
-export const initialContactFormState: ContactFormState = {
-  error: null,
 };
 
 export async function submitContactForm(
@@ -43,6 +40,7 @@ export async function submitContactForm(
         "Content-Type": "application/json",
       },
       method: "POST",
+      signal: AbortSignal.timeout(FORMSPARK_TIMEOUT_MS),
     });
 
     if (!response.ok) {

--- a/frontend/app/actions/submit-contact-form.ts
+++ b/frontend/app/actions/submit-contact-form.ts
@@ -1,0 +1,56 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { z } from "zod";
+
+const FORMSPARK_ACTION_URL = "https://submit-form.com/a0or7TBtU";
+
+const contactSubmissionSchema = z.object({
+  email: z.email().max(320),
+  message: z.string().max(5_000),
+  name: z.string().trim().min(1).max(200),
+  phone: z.string().max(50),
+});
+
+export type ContactFormState = {
+  error: string | null;
+};
+
+export const initialContactFormState: ContactFormState = {
+  error: null,
+};
+
+export async function submitContactForm(
+  _previousState: ContactFormState,
+  formData: FormData,
+): Promise<ContactFormState> {
+  const submission = contactSubmissionSchema.safeParse({
+    email: formData.get("email"),
+    message: formData.get("message"),
+    name: formData.get("name"),
+    phone: formData.get("phone"),
+  });
+
+  if (!submission.success) {
+    return { error: "Please check the form and try again." };
+  }
+
+  try {
+    const response = await fetch(FORMSPARK_ACTION_URL, {
+      body: JSON.stringify(submission.data),
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      return { error: "Your message could not be sent. Please try again." };
+    }
+  } catch {
+    return { error: "Your message could not be sent. Please try again." };
+  }
+
+  redirect("/contact/thanks/");
+}

--- a/frontend/components/blocks/contact-form-client.tsx
+++ b/frontend/components/blocks/contact-form-client.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import {
-  initialContactFormState,
   submitContactForm,
+  type ContactFormState,
 } from "@/app/actions/submit-contact-form";
 import type {
   ContactFormBlock,
@@ -20,6 +20,7 @@ type ContactFormClientProps = ContactFormBlock & {
 
 const inputClassName =
   "min-h-12 w-full rounded-control border border-input bg-background px-4 py-3.5 text-base text-foreground outline-none transition-[border-color,box-shadow] motion-fast placeholder:text-muted-foreground focus-visible:border-primary focus-ring";
+const initialContactFormState: ContactFormState = { error: null };
 
 function inputCopy(
   field: ContactFormInputCopy | null,

--- a/frontend/components/blocks/contact-form-client.tsx
+++ b/frontend/components/blocks/contact-form-client.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import {
+  initialContactFormState,
+  submitContactForm,
+} from "@/app/actions/submit-contact-form";
 import type {
   ContactFormBlock,
   ContactFormDataAttributes,
@@ -8,7 +12,7 @@ import type {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { stegaClean } from "next-sanity";
-import { useId, useRef, useState } from "react";
+import { useActionState, useId } from "react";
 
 type ContactFormClientProps = ContactFormBlock & {
   dataAttributes?: ContactFormDataAttributes;
@@ -32,13 +36,6 @@ function inputCopy(
   };
 }
 
-export function updateUnavailableMessageVisibility(
-  form: Pick<HTMLFormElement, "reportValidity"> | null,
-  setVisible: (visible: boolean) => void,
-) {
-  setVisible(Boolean(form?.reportValidity()));
-}
-
 export default function ContactFormClient({
   dataAttributes,
   description,
@@ -53,33 +50,28 @@ export default function ContactFormClient({
   privacyNote,
   submitLabel,
   title,
-  unavailableMessage,
   useCreamBackground,
 }: ContactFormClientProps) {
+  const [formState, formAction, isSubmitting] = useActionState(
+    submitContactForm,
+    initialContactFormState,
+  );
   const generatedId = useId();
   const idPrefix = `contact-${generatedId}`;
   const titleId = `${idPrefix}-title`;
   const formTitleId = `${idPrefix}-form-title`;
-  const availabilityId = `${idPrefix}-availability`;
-  const statusId = `${idPrefix}-status`;
-  const formRef = useRef<HTMLFormElement>(null);
-  const [showUnavailableMessage, setShowUnavailableMessage] = useState(false);
   const displayTitle = stegaClean(title)?.trim();
   const displayEyebrow = stegaClean(eyebrow)?.trim();
   const displayDescription = stegaClean(description)?.trim();
   const displayOfficeHoursTitle = stegaClean(officeHoursTitle)?.trim();
   const cleanFormTitle = stegaClean(formTitle)?.trim();
   const cleanSubmitLabel = stegaClean(submitLabel)?.trim();
-  const cleanUnavailableMessage = stegaClean(unavailableMessage)?.trim();
   const displayFormTitle = cleanFormTitle
     ? (formTitle ?? cleanFormTitle)
     : "Send us a message";
   const displaySubmitLabel = cleanSubmitLabel
     ? (submitLabel ?? cleanSubmitLabel)
     : "Send message";
-  const displayUnavailableMessage = cleanUnavailableMessage
-    ? (unavailableMessage ?? cleanUnavailableMessage)
-    : "Online submission is not available yet. Please contact us directly.";
   const nameCopy = inputCopy(nameField, "Name");
   const emailCopy = inputCopy(emailField, "Email");
   const phoneCopy = inputCopy(phoneField, "Phone");
@@ -166,15 +158,10 @@ export default function ContactFormClient({
         </div>
 
         <div className="rounded-card border border-border bg-card p-(--space-inset) shadow-ambient-feature">
-          {/* Keep controls unnamed and non-submitting until server-side delivery exists. */}
           <form
-            aria-describedby={availabilityId}
+            action={formAction}
             aria-labelledby={formTitleId}
             className="grid gap-5"
-            ref={formRef}
-            onSubmit={(event) => {
-              event.preventDefault();
-            }}
           >
             <h2
               className="typo-subsection-heading text-card-foreground"
@@ -197,6 +184,7 @@ export default function ContactFormClient({
                   className={inputClassName}
                   data-sanity={dataAttributes?.nameField?.placeholder}
                   id={`${idPrefix}-name`}
+                  name="name"
                   placeholder={nameCopy.placeholder}
                   required
                   type="text"
@@ -214,6 +202,7 @@ export default function ContactFormClient({
                   className={inputClassName}
                   data-sanity={dataAttributes?.emailField?.placeholder}
                   id={`${idPrefix}-email`}
+                  name="email"
                   placeholder={emailCopy.placeholder}
                   required
                   type="email"
@@ -233,6 +222,7 @@ export default function ContactFormClient({
                 className={inputClassName}
                 data-sanity={dataAttributes?.phoneField?.placeholder}
                 id={`${idPrefix}-phone`}
+                name="phone"
                 placeholder={phoneCopy.placeholder}
                 type="tel"
               />
@@ -249,6 +239,7 @@ export default function ContactFormClient({
                 className={`${inputClassName} min-h-[120px] resize-y leading-relaxed`}
                 data-sanity={dataAttributes?.messageField?.placeholder}
                 id={`${idPrefix}-message`}
+                name="message"
                 placeholder={messageCopy.placeholder}
                 rows={5}
               />
@@ -257,17 +248,10 @@ export default function ContactFormClient({
             <div className="flex flex-wrap items-center gap-5">
               <Button
                 data-sanity={dataAttributes?.submitLabel}
-                aria-controls={statusId}
-                aria-describedby={availabilityId}
-                onClick={() => {
-                  updateUnavailableMessageVisibility(
-                    formRef.current,
-                    setShowUnavailableMessage,
-                  );
-                }}
-                type="button"
+                disabled={isSubmitting}
+                type="submit"
               >
-                {displaySubmitLabel}
+                {isSubmitting ? "Sending..." : displaySubmitLabel}
               </Button>
               {stegaClean(privacyNote)?.trim() ? (
                 <p
@@ -279,27 +263,11 @@ export default function ContactFormClient({
               ) : null}
             </div>
 
-            <p className="sr-only" id={availabilityId}>
-              {displayUnavailableMessage}
-            </p>
-            <noscript>
-              <p
-                className="typo-body-sm text-primary"
-                data-sanity={dataAttributes?.unavailableMessage}
-              >
-                {displayUnavailableMessage}
+            {formState.error ? (
+              <p aria-live="polite" className="text-sm text-primary" role="alert">
+                {formState.error}
               </p>
-            </noscript>
-            <p
-              aria-atomic="true"
-              aria-live="polite"
-              className={showUnavailableMessage ? "text-sm text-primary" : "sr-only"}
-              data-sanity={dataAttributes?.unavailableMessage}
-              id={statusId}
-              role="status"
-            >
-              {showUnavailableMessage ? displayUnavailableMessage : ""}
-            </p>
+            ) : null}
           </form>
         </div>
       </div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
     "typegen": "pnpm --dir ../studio typegen",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:smoke": "playwright test e2e/footer.spec.ts"
   },
   "dependencies": {
     "@fontsource/source-serif-4": "^5.3.0",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -12,7 +12,9 @@ export default defineConfig({
     trace: "retain-on-failure",
   },
   webServer: {
-    command: "pnpm build && pnpm start",
+    command: process.env.PLAYWRIGHT_REUSE_BUILD
+      ? "pnpm start"
+      : "pnpm build && pnpm start",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 180_000,

--- a/frontend/release-gate.manual.test.ts
+++ b/frontend/release-gate.manual.test.ts
@@ -1,5 +1,0 @@
-import { expect, test } from "vitest";
-
-test("manual release gate check", () => {
-  expect("blocked").toBe("allowed");
-});

--- a/frontend/release-gate.manual.test.ts
+++ b/frontend/release-gate.manual.test.ts
@@ -1,0 +1,5 @@
+import { expect, test } from "vitest";
+
+test("manual release gate check", () => {
+  expect("blocked").toBe("allowed");
+});

--- a/frontend/sanity/lib/live.ts
+++ b/frontend/sanity/lib/live.ts
@@ -11,9 +11,9 @@ import { token } from "./token";
 export const { sanityFetch, SanityLive } = defineLive({
   client,
   // Required for showing draft content when the Sanity Presentation Tool is used, or to enable the Vercel Toolbar Edit Mode
-  serverToken: token,
+  serverToken: token || false,
   // Required for stand-alone live previews, the token is only shared to the browser if it's a valid Next.js Draft Mode session
-  browserToken: token,
+  browserToken: token || false,
   strict: true,
 });
 

--- a/frontend/sanity/lib/token.ts
+++ b/frontend/sanity/lib/token.ts
@@ -1,7 +1,3 @@
 import "server-only";
 
 export const token = process.env.SANITY_API_READ_TOKEN;
-
-if (!token) {
-  throw new Error("Missing SANITY_API_READ_TOKEN");
-}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "pnpm --dir frontend lint",
     "test": "pnpm --dir frontend test && node --test 'frontend/**/*.test.mjs' 'studio/**/*.test.mjs'",
     "test:e2e": "pnpm --dir frontend test:e2e",
+    "test:smoke": "pnpm --dir frontend test:smoke",
     "export": "cd studio && sanity dataset export production sample-data.tar.gz"
   },
   "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8",

--- a/studio/schemas/validation/redirect-rules.ts
+++ b/studio/schemas/validation/redirect-rules.ts
@@ -31,6 +31,7 @@ export const CODE_OWNED_GONE_ROUTE_PATHS = [
   "/phoenix-home-loan-payoff-vision-board",
   "/make-home-attractive-before-putting-on-market",
   "/virtual-showings-what-you-need-to-know",
+  "/spring-2021-buyers-guide",
 ] as const;
 const CODE_OWNED_SOURCE_PATHS = new Set<string>(CODE_OWNED_GONE_ROUTE_PATHS);
 const MISSING_DESTINATION_ERROR =


### PR DESCRIPTION
## Problem

Vercel could release from main without a passing test suite. Local main also held the unpushed contact form change.

## Solution

Rebase the contact form work onto current main and add one Release gate check covering typecheck, lint, unit tests, the production frontend build, and two focused browser smoke tests.

The browser tests reuse the verified production build instead of rebuilding it.

## Verification

- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --dir frontend build
- CI=1 PLAYWRIGHT_REUSE_BUILD=1 pnpm test:smoke

Built by Codex with GPT-5 in the Codex desktop app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added contact-form submission with field validation, delivery error handling, and clear submission status feedback.
  - Added a confirmation page after successful contact-form submission, including expected response timing and a link back to the contact page.
  - Reserved the `/spring-2021-buyers-guide` path for redirect management.

- **Bug Fixes**
  - Improved handling of invalid, failed, or unavailable contact-form submissions.

- **Chores**
  - Added automated release checks covering type validation, linting, tests, production builds, and browser smoke tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->