### PR TITLE
fix(header): prevent content bleed under mobile Safari chrome

### DIFF
--- a/frontend/components/header/header.test.tsx
+++ b/frontend/components/header/header.test.tsx
@@ -243,4 +243,12 @@ describe("Site Header", () => {
       vi.useRealTimers();
     }
   });
+
+  it("uses a solid background for browser toolbar color extension", () => {
+    render(<Header model={model} />);
+
+    const banner = screen.getByRole("banner");
+    expect(banner).toHaveClass("bg-background");
+    expect(banner).not.toHaveClass("bg-background/95", "backdrop-blur-md");
+  });
 });

--- a/frontend/components/header/site-header-shell.tsx
+++ b/frontend/components/header/site-header-shell.tsx
@@ -46,7 +46,7 @@ export function SiteHeaderShell({ children }: { children: ReactNode }) {
   return (
     <header
       className={cn(
-        "sticky top-0 z-[60] w-full border-b border-border/80 bg-background/95 backdrop-blur-md",
+        "sticky top-0 z-[60] w-full border-b border-border/80 bg-background",
         "transition-transform motion-slow will-change-transform motion-reduce:transition-none",
         visible ? "translate-y-0" : "-translate-y-full",
       )}


### PR DESCRIPTION
On iPhone Safari, page content could visually travel above the sticky site header while the browser toolbar collapsed. The header used a translucent background plus backdrop blur, which allowed Safari's extended viewport to show through.

This switches the sticky header to the existing solid background token. The current hide/reveal scroll thresholds and transitions are unchanged. A focused regression test prevents the translucent backdrop classes from returning.

Verified on a physical iPhone 12 Pro Safari, plus the focused header test suite and ESLint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the site header to use a solid background for improved clarity and consistency.
  * Preserved sticky positioning, borders, transitions, and responsive visibility behavior.

* **Tests**
  * Added coverage confirming the header uses the solid background style without transparency or backdrop blur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->