### PR TITLE
perf(ci): run release gate lanes in parallel against the Vercel build

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,15 @@
+name: Set up workspace
+description: Check out, install pnpm + Node.js, and install dependencies with a warm store cache.
+runs:
+  using: composite
+  steps:
+    - name: Set up pnpm and Node.js
+      uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2
+      with:
+        runtime: node@24
+        cache: true
+        install: false
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -78,3 +78,18 @@ jobs:
           PLAYWRIGHT_BASE_URL: ${{ steps.deployment.outputs.url }}
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: pnpm test:smoke
+
+  release-gate:
+    # Single stable check name for branch protection. Runs even when a lane
+    # fails (a skipped required check would otherwise block or, worse, pass).
+    name: Release gate
+    runs-on: ubuntu-latest
+    needs: [static, unit, smoke]
+    if: always()
+    steps:
+      - name: Require every lane to succeed
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          echo "$RESULTS"
+          echo "$RESULTS" | grep -qvE '"(failure|cancelled|skipped)"' || exit 1

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -13,53 +13,68 @@ concurrency:
 
 permissions:
   contents: read
+  deployments: read
 
+env:
+  NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
+  NEXT_PUBLIC_STUDIO_URL: ${{ vars.NEXT_PUBLIC_STUDIO_URL }}
+  NEXT_PUBLIC_SITE_ENV: production
+  NEXT_PUBLIC_SANITY_API_VERSION: ${{ vars.NEXT_PUBLIC_SANITY_API_VERSION }}
+  NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ vars.NEXT_PUBLIC_SANITY_PROJECT_ID }}
+  NEXT_PUBLIC_SANITY_DATASET: ${{ vars.NEXT_PUBLIC_SANITY_DATASET }}
+  OG_IMAGE_SECRET: ci-only-og-image-secret
+
+# The lanes are independent so the gate finishes when the slowest lane does,
+# not when all of them have run back to back.
 jobs:
-  release-gate:
-    name: Release gate
+  static:
+    name: Typecheck and lint
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    env:
-      NEXT_PUBLIC_SITE_URL: ${{ vars.NEXT_PUBLIC_SITE_URL }}
-      NEXT_PUBLIC_STUDIO_URL: ${{ vars.NEXT_PUBLIC_STUDIO_URL }}
-      NEXT_PUBLIC_SITE_ENV: production
-      NEXT_PUBLIC_SANITY_API_VERSION: ${{ vars.NEXT_PUBLIC_SANITY_API_VERSION }}
-      NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ vars.NEXT_PUBLIC_SANITY_PROJECT_ID }}
-      NEXT_PUBLIC_SANITY_DATASET: ${{ vars.NEXT_PUBLIC_SANITY_DATASET }}
-      OG_IMAGE_SECRET: ci-only-og-image-secret
-
+    timeout-minutes: 10
     steps:
-      - name: Check out repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
-
-      - name: Set up pnpm and Node.js
-        uses: pnpm/setup@84cb39b217b10273981911c288cd62326dc7c6d2 # v2
-        with:
-          runtime: node@24
-          cache: true
-          install: false
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
+      - uses: ./.github/actions/setup
       - name: Typecheck
         run: pnpm typecheck
-
       - name: Lint
         run: pnpm lint
 
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
       - name: Run unit tests
         run: pnpm test
 
-      - name: Build production frontend
-        run: pnpm --dir frontend build
+  smoke:
+    # Vercel already builds every commit; the smoke test runs against that
+    # deployment instead of building the site a second time on the runner.
+    name: Browser smoke tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup
 
-      - name: Install smoke-test browser
-        run: pnpm --dir frontend exec playwright install --with-deps chrome
+      - name: Wait for the Vercel deployment
+        id: deployment
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          DEPLOY_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          DEPLOY_ENVIRONMENT: ${{ github.event_name == 'pull_request' && 'Preview' || 'Production' }}
+        run: echo "url=$(node scripts/wait-for-vercel-deployment.mjs)" >> "$GITHUB_OUTPUT"
 
       - name: Run browser smoke tests
         env:
-          PLAYWRIGHT_REUSE_BUILD: "1"
+          PLAYWRIGHT_BASE_URL: ${{ steps.deployment.outputs.url }}
+          VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
         run: pnpm test:smoke

--- a/frontend/app/(main)/blog/category/category-routes.test.mjs
+++ b/frontend/app/(main)/blog/category/category-routes.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import test from "node:test";
+import { test } from "vitest";
 
 const routeSource = readFileSync(new URL("./[slug]/page.tsx", import.meta.url), "utf8");
 const paginatedRouteSource = readFileSync(new URL("./[slug]/[page]/page.tsx", import.meta.url), "utf8");

--- a/frontend/app/sitemap.test.mjs
+++ b/frontend/app/sitemap.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import test from "node:test";
+import { test } from "vitest";
 
 const source = readFileSync(new URL("./sitemap.ts", import.meta.url), "utf8");
 

--- a/frontend/components/blocks/homebot-widget-init.test.ts
+++ b/frontend/components/blocks/homebot-widget-init.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createHomebotWidgetInitializer } from "./homebot-widget-init";
 

--- a/frontend/lib/blog-index.test.mjs
+++ b/frontend/lib/blog-index.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import test from "node:test";
+import { test } from "vitest";
 
 import {
   BLOG_POSTS_PER_PAGE,

--- a/frontend/lib/redirects.test.mjs
+++ b/frontend/lib/redirects.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import { compileNextRedirects } from "./redirects.mjs";
 import { HARD_CODED_GONE_ROUTE_PATHS } from "./gone-routes.ts";

--- a/frontend/next.config.test.mjs
+++ b/frontend/next.config.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 test("next config allows the hosts discovered by the worktree launcher", async () => {
   const original = process.env.NEXT_ALLOWED_DEV_ORIGINS;
@@ -7,9 +7,8 @@ test("next config allows the hosts discovered by the worktree launcher", async (
     "192.168.100.233, forge.example-tailnet.ts.net,192.168.100.233";
 
   try {
-    const { default: nextConfig } = await import(
-      `./next.config.mjs?allowed-origins-test=${Date.now()}`
-    );
+    // Each vitest file gets a fresh module graph, so a plain import sees the env above.
+    const { default: nextConfig } = await import("./next.config.mjs");
 
     assert.deepEqual(nextConfig.allowedDevOrigins, [
       "192.168.100.233",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,10 @@
 import { defineConfig } from "@playwright/test";
 
+// CI points the smoke test at the Vercel deployment for the commit instead of
+// rebuilding; locally Playwright still builds and serves the app itself.
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+const bypassSecret = process.env.VERCEL_AUTOMATION_BYPASS_SECRET;
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: true,
@@ -7,16 +12,19 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: "list",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL,
     channel: "chrome",
     trace: "retain-on-failure",
+    extraHTTPHeaders: bypassSecret
+      ? { "x-vercel-protection-bypass": bypassSecret, "x-vercel-set-bypass-cookie": "true" }
+      : undefined,
   },
-  webServer: {
-    command: process.env.PLAYWRIGHT_REUSE_BUILD
-      ? "pnpm start"
-      : "pnpm build && pnpm start",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
-    timeout: 180_000,
-  },
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: process.env.PLAYWRIGHT_REUSE_BUILD ? "pnpm start" : "pnpm build && pnpm start",
+        url: baseURL,
+        reuseExistingServer: !process.env.CI,
+        timeout: 180_000,
+      },
 });

--- a/frontend/sanity/queries/blog-post-settings.test.mjs
+++ b/frontend/sanity/queries/blog-post-settings.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import test from "node:test";
+import { test } from "vitest";
 
 const source = readFileSync(new URL("./blog-post-settings.ts", import.meta.url), "utf8");
 

--- a/frontend/sanity/queries/internal-href.test.mjs
+++ b/frontend/sanity/queries/internal-href.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import test from "node:test";
+import { test } from "vitest";
 
 const source = readFileSync(new URL("./shared/internal-href.ts", import.meta.url), "utf8");
 const footerSource = readFileSync(new URL("./footer.ts", import.meta.url), "utf8");

--- a/frontend/sanity/queries/root-slug-filter.test.mjs
+++ b/frontend/sanity/queries/root-slug-filter.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import test from "node:test";
+import { test } from "vitest";
 import { ROOT_SLUG_FILTER } from "../../../shared/root-slug-filter.ts";
 
 test("root content queries accept every surrounding-slash variant", () => {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,10 @@
 import path from "node:path";
 import { defineConfig } from "vitest/config";
 
+const repoRoot = path.resolve(__dirname, "..");
+
+// Only component tests (.tsx) pay for a jsdom environment; it dominated CI
+// time (33s of environment setup for 5s of tests). Logic tests run in node.
 export default defineConfig({
   resolve: {
     alias: {
@@ -16,8 +20,33 @@ export default defineConfig({
       NEXT_PUBLIC_SANITY_PROJECT_ID: "test-project",
       OG_IMAGE_SECRET: "test-only-og-image-secret",
     },
-    environment: "jsdom",
-    include: ["**/*.test.{ts,tsx}"],
-    setupFiles: ["./vitest.setup.ts"],
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "dom",
+          include: ["**/*.test.tsx"],
+          environment: "jsdom",
+          setupFiles: ["./vitest.setup.ts"],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "node",
+          include: ["**/*.test.ts"],
+          environment: "node",
+        },
+      },
+      {
+        // Repo-wide script/schema tests, formerly run by `node --test`.
+        test: {
+          name: "scripts",
+          root: repoRoot,
+          include: ["frontend/**/*.test.mjs", "studio/**/*.test.mjs", "scripts/*.test.mjs"],
+          environment: "node",
+        },
+      },
+    ],
   },
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "typegen": "cd studio && pnpm typegen",
     "typecheck": "pnpm --dir frontend typecheck && pnpm --dir studio typecheck",
     "lint": "pnpm --dir frontend lint",
-    "test": "pnpm --dir frontend test && node --test 'frontend/**/*.test.mjs' 'studio/**/*.test.mjs' 'scripts/*.test.mjs'",
+    "test": "pnpm --dir frontend test",
     "test:e2e": "pnpm --dir frontend test:e2e",
     "test:smoke": "pnpm --dir frontend test:smoke",
     "export": "cd studio && sanity dataset export production sample-data.tar.gz"

--- a/scripts/dev-worktree.test.mjs
+++ b/scripts/dev-worktree.test.mjs
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import test from "node:test";
+import { onTestFinished, test } from "vitest";
 
 import {
   devServerCommands,
@@ -180,11 +180,11 @@ test("derivePortPair returns a stable pair in separate ranges", () => {
   assert.equal(first.studio - first.frontend, 1000);
 });
 
-test("selectPortPair replaces a saved pair from the old wide range", async (context) => {
+test("selectPortPair replaces a saved pair from the old wide range", async () => {
   const worktreePath = await mkdtemp(resolve(tmpdir(), "dev-worktree-test-"));
   const portFile = resolve(worktreePath, ".worktree-ports.json");
 
-  context.after(() => rm(worktreePath, { force: true, recursive: true }));
+  onTestFinished(() => rm(worktreePath, { force: true, recursive: true }));
   await writeFile(portFile, '{"frontend":3923,"studio":4923}\n');
 
   const selected = await selectPortPair({
@@ -197,13 +197,13 @@ test("selectPortPair replaces a saved pair from the old wide range", async (cont
   assert.deepEqual(saved, selected.pair);
 });
 
-test("selectPortPair skips occupied pairs and remembers its choice", async (context) => {
+test("selectPortPair skips occupied pairs and remembers its choice", async () => {
   const worktreePath = await mkdtemp(resolve(tmpdir(), "dev-worktree-test-"));
   const firstPair = derivePortPair(worktreePath);
   const occupiedPorts = new Set([firstPair.frontend, firstPair.studio]);
   const checkPort = async (port) => !occupiedPorts.has(port);
 
-  context.after(() => rm(worktreePath, { force: true, recursive: true }));
+  onTestFinished(() => rm(worktreePath, { force: true, recursive: true }));
 
   const selected = await selectPortPair({ worktreePath, checkPort });
   const saved = JSON.parse(await readFile(resolve(worktreePath, ".worktree-ports.json")));

--- a/scripts/setup-sanity-cors.test.mjs
+++ b/scripts/setup-sanity-cors.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import {
   desiredCorsOrigins,

--- a/scripts/wait-for-vercel-deployment.mjs
+++ b/scripts/wait-for-vercel-deployment.mjs
@@ -1,0 +1,56 @@
+// Resolve the Vercel deployment URL for a commit from the GitHub Deployments
+// API (populated by the Vercel GitHub integration) and wait until it succeeds.
+// Prints the URL on stdout so a workflow step can capture it.
+//
+// Env: GITHUB_REPOSITORY, GITHUB_TOKEN, DEPLOY_SHA, DEPLOY_ENVIRONMENT
+// ("Preview" | "Production"), optional DEPLOY_TIMEOUT_MS (default 10 min).
+
+const { GITHUB_REPOSITORY, GITHUB_TOKEN, DEPLOY_SHA, DEPLOY_ENVIRONMENT } = process.env;
+const timeoutMs = Number(process.env.DEPLOY_TIMEOUT_MS ?? 10 * 60 * 1000);
+const pollMs = 10_000;
+
+for (const [name, value] of Object.entries({ GITHUB_REPOSITORY, GITHUB_TOKEN, DEPLOY_SHA, DEPLOY_ENVIRONMENT })) {
+  if (!value) throw new Error(`Missing ${name}`);
+}
+
+const headers = {
+  Accept: "application/vnd.github+json",
+  Authorization: `Bearer ${GITHUB_TOKEN}`,
+  "X-GitHub-Api-Version": "2022-11-28",
+};
+
+async function github(path) {
+  const response = await fetch(`https://api.github.com/repos/${GITHUB_REPOSITORY}${path}`, { headers });
+  if (!response.ok) throw new Error(`GitHub API ${path} -> ${response.status}`);
+  return response.json();
+}
+
+async function findDeployment() {
+  const query = new URLSearchParams({ sha: DEPLOY_SHA, environment: DEPLOY_ENVIRONMENT, per_page: "5" });
+  const deployments = await github(`/deployments?${query}`);
+  for (const deployment of deployments) {
+    const statuses = await github(`/deployments/${deployment.id}/statuses?per_page=1`);
+    const latest = statuses[0];
+    if (!latest) continue;
+    if (latest.state === "success") return { url: latest.environment_url || latest.target_url };
+    if (["failure", "error"].includes(latest.state)) {
+      throw new Error(`Vercel ${DEPLOY_ENVIRONMENT} deployment for ${DEPLOY_SHA} ended with state "${latest.state}"`);
+    }
+  }
+  return null;
+}
+
+const deadline = Date.now() + timeoutMs;
+for (;;) {
+  const found = await findDeployment();
+  if (found) {
+    console.error(`Vercel ${DEPLOY_ENVIRONMENT} deployment ready: ${found.url}`);
+    console.log(found.url);
+    break;
+  }
+  if (Date.now() > deadline) {
+    throw new Error(`Timed out after ${timeoutMs}ms waiting for Vercel ${DEPLOY_ENVIRONMENT} deployment of ${DEPLOY_SHA}`);
+  }
+  console.error(`Waiting for Vercel ${DEPLOY_ENVIRONMENT} deployment of ${DEPLOY_SHA.slice(0, 7)}...`);
+  await new Promise((r) => setTimeout(r, pollMs));
+}

--- a/studio/big-video-feature.test.mjs
+++ b/studio/big-video-feature.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import { getYouTubeVideoId as getFrontendVideoId } from "../frontend/lib/youtube-video-id.ts";
 import { getYouTubeVideoId as getStudioVideoId } from "./schemas/blocks/big-video-feature.ts";

--- a/studio/blog-index-contract.test.mjs
+++ b/studio/blog-index-contract.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import {
   blocksField,

--- a/studio/environment.test.mjs
+++ b/studio/environment.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import { requireStudioDataset } from "./environment.ts";
 

--- a/studio/functions/auto-redirect/model.test.mjs
+++ b/studio/functions/auto-redirect/model.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import {
   autoRedirectId,

--- a/studio/loan-feature-cards.test.mjs
+++ b/studio/loan-feature-cards.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { test } from "node:test";
+import { test } from "vitest";
 import { validateHelpCard } from "./schemas/blocks/loan-feature-cards.ts";
 
 const complete = {

--- a/studio/migrations/migrate-page-seo-metadata/index.test.mjs
+++ b/studio/migrations/migrate-page-seo-metadata/index.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import {
   buildPageSeoOperations,

--- a/studio/migrations/portable-text-custom-links/index.test.mjs
+++ b/studio/migrations/portable-text-custom-links/index.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   convertLegacyLinkMark,
   planPortableTextLinkMigration,

--- a/studio/presentation/presentation.test.mjs
+++ b/studio/presentation/presentation.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import {
   getDocumentSlug,
   getPresentationPath,

--- a/studio/schemas/validation/redirect-rules.test.mjs
+++ b/studio/schemas/validation/redirect-rules.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import { HARD_CODED_GONE_ROUTE_PATHS } from "../../../frontend/lib/gone-routes.ts";
 import {

--- a/studio/schemas/validation/single-faq-block.test.mjs
+++ b/studio/schemas/validation/single-faq-block.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import { singleFaqBlock } from "./single-faq-block.ts";
 

--- a/studio/schemas/validation/unique-category-slug.test.mjs
+++ b/studio/schemas/validation/unique-category-slug.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import { uniqueCategorySlug } from "./unique-category-slug.ts";
 

--- a/studio/schemas/validation/unique-root-slug.test.mjs
+++ b/studio/schemas/validation/unique-root-slug.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import { uniqueRootSlug } from "./unique-root-slug.ts";
 

--- a/studio/scripts/build-conventional-loan-page.test.mjs
+++ b/studio/scripts/build-conventional-loan-page.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import {
   CONVENTIONAL_LOAN_CONTENT,

--- a/studio/scripts/lucide-icon-catalog.test.mjs
+++ b/studio/scripts/lucide-icon-catalog.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import test from "node:test";
+import { test } from "vitest";
 import { fileURLToPath } from "node:url";
 import { dynamicIconImports } from "lucide-react/dynamic.mjs";
 import {

--- a/studio/scripts/migrate-award-cta-to-settings.test.mjs
+++ b/studio/scripts/migrate-award-cta-to-settings.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import {
   buildAwardBlockUnsetPaths,

--- a/studio/scripts/migrate-blog-index.test.mjs
+++ b/studio/scripts/migrate-blog-index.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import {
   buildBlogIndexMutation,

--- a/studio/scripts/migrate-category-taxonomy.test.mjs
+++ b/studio/scripts/migrate-category-taxonomy.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { test } from "node:test";
+import { test } from "vitest";
 
 import {
   CATEGORY_PLAN,

--- a/studio/scripts/migrate-footer.test.mjs
+++ b/studio/scripts/migrate-footer.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { footerColumnsFromLegacySections, migrationPatch } from "./migrate-footer.mjs";
 
 const link = (key, label) => ({

--- a/studio/scripts/migrate-legacy-category-redirects.test.mjs
+++ b/studio/scripts/migrate-legacy-category-redirects.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import { autoRedirectId } from "../functions/auto-redirect/model.ts";
 import {

--- a/studio/scripts/migrate-navigation-categories.test.mjs
+++ b/studio/scripts/migrate-navigation-categories.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { test } from "node:test";
+import { test } from "vitest";
 
 import {
   EXPECTED_CATEGORY_SLUGS,

--- a/studio/scripts/migrate-navigation.test.mjs
+++ b/studio/scripts/migrate-navigation.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 import { transformLegacyNavbar } from "./migrate-navigation.mjs";
 
 test("transforms the legacy navbar into the canonical navigation model", () => {

--- a/studio/scripts/migrate-post-category.test.mjs
+++ b/studio/scripts/migrate-post-category.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import { test } from "vitest";
 
 import {
   CATEGORY_SLUGS,


### PR DESCRIPTION
## Why

The release gate took ~150s serially while Vercel finished its build in ~30s. Per-step timing showed the cost was structural, not the checks: unit tests spent 33s building jsdom environments for 5s of tests, 25s installed a Chrome the runner already ships, and the runner rebuilt a site Vercel had already built.

## What

- Split the workflow into `static` / `unit` / `smoke` jobs sharing a composite setup action, so wall clock is the slowest lane rather than the sum.
- Smoke tests run against the commit's Vercel deployment, resolved via the GitHub Deployments API by `scripts/wait-for-vercel-deployment.mjs`. Requires the `VERCEL_AUTOMATION_BYPASS_SECRET` repo secret (previews sit behind Vercel Authentication). Local `test:smoke` still self-builds.
- Drop the Chrome install step; `ubuntu-latest` already has it.
- Vitest runs three projects: jsdom only for `.tsx` component tests, node for `.ts` logic tests, and a repo-wide project absorbing the former `node --test` files. One runner, one process.

## Proof

- `pnpm test`: 66 files, 437 tests, 3.2s locally (was ~30s in CI)
- `pnpm typecheck` and `pnpm lint` clean
- Wait script verified against the last real preview deployment

The gate on this PR exercises the Preview path; the Production path first runs on the merge to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized automated test execution with Vitest across frontend, studio, and tooling suites.
  * Improved test environment separation for browser-based and server-side tests.
  * Added dependency setup and caching for consistent CI runs.

* **Tests**
  * Release checks now run independently for type checking, linting, unit tests, and browser smoke tests.
  * Browser smoke tests can run against an existing deployment.
  * Added deployment monitoring to wait for and validate the appropriate deployment before testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->