### PR TITLE
feat(scripts): add presentation:url helper for reviewing content edits

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,16 @@ This repository uses a single-context domain-doc layout. See `docs/agents/domain
 
 Before adding or changing a Page Builder section, read `docs/agents/page-builder.md`.
 
+### Reviewing Sanity content edits
+
+After editing dataset content, give the user a clickable Studio Presentation URL for the exact page. Get it with:
+
+```bash
+pnpm presentation:url <documentType> [slug]   # e.g. pnpm presentation:url page about
+```
+
+It resolves the Studio port for this checkout or worktree and warns if the Studio is not running.
+
 ### Development workflow
 
 Before changing workspace dependencies, Sanity schemas, GROQ queries, or development scripts, consult the relevant section of `README.md`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ ports `4100`–`4109`. Set both `FRONTEND_PORT` and `STUDIO_PORT` before the com
 override the assigned pair. Both servers listen on all local network interfaces, and the
 command prints the frontend's current LAN URL.
 
+To get a clickable Studio Presentation URL for a document (for example after a content edit), run
+`pnpm presentation:url <documentType> [slug]`. It uses the Studio port assigned to the current
+checkout or worktree.
+
 When Tailscale is connected, the same command also publishes only the frontend through a
 private HTTPS Tailscale Serve URL. Its HTTPS ports are `5100`–`5109`—for example, frontend
 port `3103` is published on Tailscale port `5103`. Use the exact `Phone HTTPS` URL printed by

--- a/package.json
+++ b/package.json
@@ -3,12 +3,16 @@
   "version": "2.0.0",
   "description": "phxhomeloan.com website and CMS",
   "private": true,
+  "engines": {
+    "node": ">=22.18"
+  },
   "scripts": {
     "dev": "pnpm --parallel -r run dev",
     "dev:frontend": "pnpm run dev --workspace=frontend",
     "dev:prototype": "python3 -m http.server 8000 --bind 127.0.0.1 --directory frontend/PHXHomeLoan-web-prototype",
     "dev:studio": "pnpm run dev --workspace=studio",
     "dev:worktree": "node scripts/dev-worktree.mjs",
+    "presentation:url": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/presentation-url.mjs",
     "setup:sanity-cors": "node scripts/setup-sanity-cors.mjs",
     "setup:worktree": "node scripts/copy-worktree-env.mjs",
     "audit:seo-titles": "pnpm --dir studio audit:seo-titles",

--- a/scripts/presentation-url.mjs
+++ b/scripts/presentation-url.mjs
@@ -1,0 +1,114 @@
+// Print the local Studio Presentation URL for a content document, so a
+// reviewer can click straight to the page after a dataset edit.
+//
+//   pnpm presentation:url <documentType> [slug]
+//   pnpm presentation:url page about
+//   pnpm presentation:url blogIndex
+//
+// The path comes from the same resolver the Studio's "Open in Presentation"
+// action uses (studio/presentation/routes.ts), so the two never disagree.
+// The Studio port is resolved the same way `pnpm dev:worktree` assigns it:
+// STUDIO_PORT, then .worktree-ports.json, then the plain `pnpm dev` port.
+
+import { readFile } from "node:fs/promises";
+import { createConnection } from "node:net";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getPresentationPath } from "../studio/presentation/routes.ts";
+
+const DEFAULT_STUDIO_PORT = 3333;
+const PORT_FILE_NAME = ".worktree-ports.json";
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function parsePort(value, name) {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+    throw new Error(`${name} must be an integer from 1024 through 65535.`);
+  }
+  return port;
+}
+
+export async function resolveStudioPort({
+  projectRoot = REPO_ROOT,
+  studioOverride = process.env.STUDIO_PORT,
+} = {}) {
+  if (studioOverride) {
+    return { port: parsePort(studioOverride, "STUDIO_PORT"), source: "STUDIO_PORT" };
+  }
+
+  const portFile = resolve(projectRoot, PORT_FILE_NAME);
+  let saved;
+  try {
+    saved = JSON.parse(await readFile(portFile, "utf8"));
+  } catch (error) {
+    if (error?.code !== "ENOENT") {
+      throw new Error(`Could not read ${portFile}: ${error.message}`, { cause: error });
+    }
+    return { port: DEFAULT_STUDIO_PORT, source: "default" };
+  }
+
+  return { port: parsePort(saved?.studio, `Studio port in ${portFile}`), source: portFile };
+}
+
+export function buildPresentationUrl(studioPort, documentType, slug) {
+  const path = getPresentationPath(documentType, slug);
+  if (!path) {
+    throw new Error(
+      `No Presentation route for type "${documentType}"` +
+        (slug ? ` with slug "${slug}".` : ". Pass the document's slug."),
+    );
+  }
+
+  const url = new URL(`http://localhost:${studioPort}/presentation`);
+  url.searchParams.set("preview", path);
+  return url.toString();
+}
+
+export function isPortListening(port, host = "localhost") {
+  return new Promise((resolveListening) => {
+    const socket = createConnection({ host, port });
+    socket.setTimeout(500);
+    socket.once("connect", () => {
+      socket.destroy();
+      resolveListening(true);
+    });
+    const fail = () => {
+      socket.destroy();
+      resolveListening(false);
+    };
+    socket.once("error", fail);
+    socket.once("timeout", fail);
+  });
+}
+
+async function main(argv) {
+  const [documentType, slug] = argv;
+  if (!documentType) {
+    console.error("Usage: pnpm presentation:url <documentType> [slug]");
+    process.exitCode = 2;
+    return;
+  }
+
+  const { port, source } = await resolveStudioPort();
+  const url = buildPresentationUrl(port, documentType, slug);
+
+  if (!(await isPortListening(port))) {
+    console.warn(
+      `Warning: nothing is listening on Studio port ${port} (from ${source}). ` +
+        "Start it with `pnpm dev` or `pnpm dev:worktree`.",
+    );
+  }
+
+  console.log(url);
+}
+
+const isMainModule =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isMainModule) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/presentation-url.test.mjs
+++ b/scripts/presentation-url.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { onTestFinished, test } from "vitest";
+
+import { buildPresentationUrl, resolveStudioPort } from "./presentation-url.mjs";
+
+async function temporaryProjectRoot() {
+  const root = await mkdtemp(resolve(tmpdir(), "presentation-url-"));
+  onTestFinished(() => rm(root, { recursive: true, force: true }));
+  return root;
+}
+
+test("builds the Presentation URL from the shared route resolver", () => {
+  assert.equal(
+    buildPresentationUrl(3333, "page", "about"),
+    "http://localhost:3333/presentation?preview=%2Fabout%2F",
+  );
+  assert.equal(
+    buildPresentationUrl(4102, "category", "loan-types"),
+    "http://localhost:4102/presentation?preview=%2Fblog%2Fcategory%2Floan-types%2F",
+  );
+  assert.equal(
+    buildPresentationUrl(3333, "blogIndex"),
+    "http://localhost:3333/presentation?preview=%2Fblog%2F",
+  );
+  assert.equal(
+    buildPresentationUrl(3333, "homePage"),
+    "http://localhost:3333/presentation?preview=%2F",
+  );
+});
+
+test("rejects documents that have no Presentation route", () => {
+  assert.throws(() => buildPresentationUrl(3333, "page"), /Pass the document's slug/);
+  assert.throws(() => buildPresentationUrl(3333, "author", "jane"), /No Presentation route/);
+});
+
+test("falls back to the plain `pnpm dev` Studio port", async () => {
+  const projectRoot = await temporaryProjectRoot();
+  assert.deepEqual(await resolveStudioPort({ projectRoot, studioOverride: "" }), {
+    port: 3333,
+    source: "default",
+  });
+});
+
+test("reads the Studio port assigned by `pnpm dev:worktree`", async () => {
+  const projectRoot = await temporaryProjectRoot();
+  const portFile = resolve(projectRoot, ".worktree-ports.json");
+  await writeFile(portFile, JSON.stringify({ frontend: 3104, studio: 4104 }));
+
+  assert.deepEqual(await resolveStudioPort({ projectRoot, studioOverride: "" }), {
+    port: 4104,
+    source: portFile,
+  });
+});
+
+test("rejects a saved Studio port outside the usable range", async () => {
+  const projectRoot = await temporaryProjectRoot();
+  await writeFile(
+    resolve(projectRoot, ".worktree-ports.json"),
+    JSON.stringify({ frontend: 3104, studio: 80 }),
+  );
+
+  await assert.rejects(
+    resolveStudioPort({ projectRoot, studioOverride: "" }),
+    /Studio port in .*worktree-ports\.json must be an integer/,
+  );
+});
+
+test("STUDIO_PORT overrides the saved worktree port", async () => {
+  const projectRoot = await temporaryProjectRoot();
+  await writeFile(
+    resolve(projectRoot, ".worktree-ports.json"),
+    JSON.stringify({ frontend: 3104, studio: 4104 }),
+  );
+
+  assert.deepEqual(await resolveStudioPort({ projectRoot, studioOverride: "4109" }), {
+    port: 4109,
+    source: "STUDIO_PORT",
+  });
+  await assert.rejects(
+    resolveStudioPort({ projectRoot, studioOverride: "80" }),
+    /STUDIO_PORT must be an integer/,
+  );
+});


### PR DESCRIPTION
## Summary

- Adds `pnpm presentation:url <documentType> [slug]`, which prints a clickable Studio Presentation URL for a content document.
- Reuses the Studio's own route resolver (`studio/presentation/routes.ts`), so the URL matches the "Open in Presentation" action exactly.
- Resolves the Studio port the same way `pnpm dev:worktree` does: `STUDIO_PORT`, then `.worktree-ports.json`, then 3333. Warns when nothing listens on that port.
- Declares `engines.node >= 22.18` because the script imports a `.ts` module via native type stripping. CI already runs Node 24.
- Documents the command in `CLAUDE.md` (agent instruction) and `README.md`.

## Why

After an agent edits dataset content, the reviewer wants a direct link to the exact page in Presentation mode. The URL is deterministic, so a script removes the guesswork.

## Test plan

- [x] `scripts/presentation-url.test.mjs` (6 tests) and existing `studio/presentation/presentation.test.mjs` pass under vitest
- [x] `pnpm presentation:url page about` against a running Studio prints `http://localhost:3333/presentation?preview=%2Fabout%2F`, which opens Presentation on `/about/` in drafts perspective
- [x] Unsupported type, missing slug, and out-of-range ports fail with clear messages
- [x] CodeRabbit local review: clean after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
