### PR TITLE
fix(fha): qualify assistance and loan guidance

### DIFF
--- a/docs/editorial/issue-75-completion-evidence.md
+++ b/docs/editorial/issue-75-completion-evidence.md
@@ -1,0 +1,69 @@
+# Issue 75 completion evidence
+
+Reviewed and published on 2026-09-03 for GitHub issue [#75](https://github.com/ovsw/phxhomeloancom-2026/issues/75).
+
+## Source decisions
+
+The update applies the FHA and Home in Five decisions in the [issue 72 factual source ledger](./issue-72-factual-source-ledger.md):
+
+- Preserve the mature FHA page, its six FAQ references, FHA video, contact links, phone links, and Apply route.
+- Keep Jimmy's FAQ topics from the [FHA rebuild task](https://app.basecamp.com/6230954/buckets/47793039/todos/10024681267), but qualify each answer against program rules, lender requirements, property review, and full approval.
+- Describe FHA and conventional loans as a borrower-specific cost comparison. Do not state that one is always better.
+- Replace Home in Five's universal figures and terms with product-specific language.
+- Remove the unsupported military bonus and all promises of funding, eligibility, approval, or forgiveness.
+- Treat the duplicate factual-review attachment noted in the ledger as a verified no-op.
+
+The publication-day Home in Five review found no basis for one set of current terms. The program resources showed exhausted or closed funding notices and distinct 3-, 7-, 10-, and 30-year lien structures. The overview and product material also conflicted on income limits. Direct requests to the ledger's overview, resources, and three linked product documents returned HTTP 404 on 2026-09-03. The page therefore gives no assistance percentage, income cap, score, debt-to-income limit, education duration, interest rate, payment schedule, lien duration, forgiveness schedule, or availability promise.
+
+Current CFPB consumer pages confirmed the narrower FHA explanation:
+
+- [What is an FHA loan?](https://www.consumerfinance.gov/ask-cfpb/what-is-an-fha-loan-en-112/)
+- [FHA loans](https://www.consumerfinance.gov/owning-a-home/fha-loans/)
+- [Conventional loans](https://www.consumerfinance.gov/owning-a-home/conventional-loans/)
+- [What is private mortgage insurance?](https://www.consumerfinance.gov/ask-cfpb/what-is-private-mortgage-insurance-en-122/)
+
+HUD Handbook 4000.1 remains the controlling program source for the FHA score tiers and mortgage-insurance duration rules. HUD blocked the automated publication-day request with HTTP 403. To avoid claims that could not be rechecked, the update removed exact seller-contribution and gift-fund percentages. The remaining copy tells readers that lender overlays and full underwriting apply.
+
+## Basecamp mapping
+
+- [FHA rebuild](https://app.basecamp.com/6230954/buckets/47793039/todos/10024681267): retained the supplied FAQ topics and FHA video `H-2VebTO_YU`.
+- [Down-payment assistance factual data](https://app.basecamp.com/6230954/buckets/47793039/todos/10225421495): followed Jimmy's direction to use active official information rather than the old figures.
+- [FHA versus Conventional](https://app.basecamp.com/6230954/buckets/47793039/todos/10024684227): retained the comparison and interim video `2-5z3fhUAOA` where already used.
+
+These Basecamp tasks were already complete. Issue 75 did not reopen, close, or change them.
+
+## Sanity state
+
+Project `hv0545v9`, dataset `development`:
+
+- Page: `fhaLoan`, revision `MfE7T9i1Cy3CNY6r5N6vCg`
+- FAQs: `faq-fha-what-is-it`, `faq-fha-down-payment`, `faq-fha-credit-score`, `faq-fha-mip-vs-pmi`, `faq-fha-first-time-buyers`, and `faq-fha-refinance-later`
+- Mutation: one revision-guarded transaction for the page and six FAQ documents
+- Verification: intended state present in both `published` and `raw` perspectives
+- Target drafts: zero
+
+Sanity validation found no target errors and no new warnings. The page still has its existing `migrationSource` warning because that provenance field is outside the current schema. The update did not add or remove that field.
+
+## Rendered proof
+
+The page was checked at `http://localhost:3107/phoenix-fha-loan/` with the Next.js development server:
+
+- Page title: `FHA Mortgage Loan in Phoenix | The Vercellino Team`
+- H1: `The FHA Home Loan`
+- Metadata and `LoanOrCredit` description use the same revised description.
+- The page contains the qualified Home in Five language and none of the removed dollar, percentage, or forgiveness claims.
+- Contact, Apply, and phone links resolve to the intended routes.
+- Six canonical FAQ questions render. `FAQPage` JSON-LD contains the same six questions and answers.
+- The FHA `VideoObject` uses Jimmy's supplied video.
+- FAQ pointer interaction opened its answer.
+
+The shared browser's resize command timed out, so it could not produce a new mobile viewport capture. Its keyboard command also did not activate the focused FAQ button. These were preview-control failures, not page runtime errors. The route compiled without Next.js errors, and the focused structured-data and component tests passed. A final human mobile and keyboard check remains appropriate before production publication.
+
+## Automated proof
+
+- FHA mutation tests: 4 passed.
+- Frontend FAQ, loan, and video structured-data tests: 28 passed.
+- Studio typecheck: passed.
+- Next.js runtime diagnostics: no compilation or session errors.
+- Repository typecheck: passed.
+- Full Vitest suite: 68 files and 448 tests passed.

--- a/studio/scripts/revise-fha-loan-page.test.mjs
+++ b/studio/scripts/revise-fha-loan-page.test.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { test } from "vitest";
+
+import {
+  FAQ_IDS,
+  buildFaqMutation,
+  buildPageMutation,
+  validatePage,
+} from "./revise-fha-loan-page.ts";
+
+const paragraph = (key, text) => ({
+  _key: key,
+  _type: "block",
+  children: [{ _key: `${key}-old`, _type: "span", marks: [], text }],
+  markDefs: [],
+  style: "normal",
+});
+
+const source = {
+  _id: "fhaLoan",
+  _rev: "page-revision",
+  _type: "page",
+  slug: { current: "/phoenix-fha-loan" },
+  description: "old",
+  meta: { title: "FHA Mortgage Loan in Phoenix", noindex: false, description: "old" },
+  blocks: [
+    {
+      _key: "page-header-fha",
+      statistics: [
+        { _key: "stat-down" },
+        { _key: "stat-score" },
+        { _key: "stat-seller" },
+      ],
+    },
+    {
+      _key: "chapter-what-it-is",
+      richText: [paragraph("what-p1", "old"), paragraph("what-p2", "old")],
+      supportingContent: [{ _key: "impact-down-payment", statement: "$14,000" }],
+    },
+    {
+      _key: "table-fha-vs-conventional",
+      table: {
+        rows: ["row-down", "row-credit", "row-mi", "row-seller", "row-best"].map(
+          (_key) => ({ _key, cells: ["old", "old", "old"] }),
+        ),
+      },
+    },
+    {
+      _key: "benefit-cards-advantages",
+      cards: ["adv-down", "adv-gift", "adv-credit", "adv-seller", "adv-prepay"].map(
+        (_key) => ({ _key, title: "old", body: [paragraph(`${_key}-p`, "old")] }),
+      ),
+    },
+    {
+      _key: "loan-requirements",
+      chapters: [
+        {
+          _key: "credit",
+          body: [paragraph("credit-p1", "old")],
+        },
+        {
+          _key: "money-up-front",
+          body: [paragraph("money-p1", "old")],
+          evidence: [
+            {
+              _key: "money-stats",
+              stats: [{ _key: "stat-gift" }],
+            },
+          ],
+        },
+        {
+          _key: "mortgage-insurance",
+          body: [paragraph("mip-p1", "old")],
+          evidence: [
+            {
+              _key: "mip-tiers",
+              tiers: [{ _key: "tier-duration" }],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      _key: "chapter-home-in-five",
+      richText: [paragraph("hi5-p1", "old"), paragraph("hi5-p2", "old")],
+      supportingContent: [{ _key: "impact-hi5" }],
+    },
+    {
+      _key: "fha-faq",
+      faqs: FAQ_IDS.map((_ref) => ({ _key: `ref-${_ref}`, _ref, _type: "reference" })),
+    },
+    {
+      _key: "advisor-cta-why-fha",
+      richText: [paragraph("why-p1", "old"), paragraph("why-p2", "old")],
+      buttons: [
+        { _key: "apply", url: { internal: { _ref: "apply" } } },
+        { _key: "phone", url: { external: "tel:4808008387" } },
+      ],
+    },
+  ],
+};
+
+test("validates the stable FHA page identity", () => {
+  assert.equal(validatePage(source), undefined);
+  assert.match(validatePage(undefined), /does not exist/);
+  assert.match(validatePage({ ...source, _type: "post" }), /Expected the published page/);
+  assert.match(validatePage({ ...source, slug: { current: "/other" } }), /slug.current/);
+});
+
+test("revises risky claims while preserving canonical references and routes", () => {
+  const mutation = buildPageMutation(source);
+  const text = JSON.stringify(mutation.set);
+
+  assert.equal(mutation.id, "fhaLoan");
+  assert.equal(mutation.ifRevisionID, "page-revision");
+  assert.equal(mutation.set.meta.title, "FHA Mortgage Loan in Phoenix");
+  assert.equal(mutation.set.meta.noindex, false);
+  assert.match(text, /There is no single Home in Five percentage/);
+  assert.match(text, /Lenders can require a higher score/);
+  assert.match(text, /11 years/);
+  assert.doesNotMatch(
+    text,
+    /\$157,360|\$24,000|3% to 6%|Up to 6%|Up to 100%|forgiven step by step/,
+  );
+
+  const faq = mutation.set.blocks.find((block) => block._key === "fha-faq");
+  assert.deepEqual(
+    faq.faqs.map(({ _ref }) => _ref),
+    FAQ_IDS,
+  );
+  const advisor = mutation.set.blocks.find(
+    (block) => block._key === "advisor-cta-why-fha",
+  );
+  assert.equal(advisor.title, "Your Phoenix FHA loan team");
+  assert.equal(advisor.buttons[0].url.internal._ref, "apply");
+  assert.equal(advisor.buttons[1].url.external, "tel:4808008387");
+});
+
+test("builds two-paragraph mutations for all canonical FAQ documents", () => {
+  for (const id of FAQ_IDS) {
+    const mutation = buildFaqMutation({ _id: id, _rev: `${id}-rev`, _type: "faq" });
+    assert.equal(mutation.id, id);
+    assert.equal(mutation.ifRevisionID, `${id}-rev`);
+    assert.equal(mutation.set.body.length, 2);
+    assert.ok(mutation.set.body.every((block) => block.children[0].text.length > 30));
+  }
+});
+
+test("does not accept an unknown or wrong-type FAQ", () => {
+  assert.throws(
+    () => buildFaqMutation({ _id: "other", _rev: "rev", _type: "faq" }),
+    /Unexpected FAQ/,
+  );
+  assert.throws(
+    () =>
+      buildFaqMutation({
+        _id: FAQ_IDS[0],
+        _rev: "rev",
+        _type: "page",
+      }),
+    /is not an FAQ/,
+  );
+});

--- a/studio/scripts/revise-fha-loan-page.test.mjs
+++ b/studio/scripts/revise-fha-loan-page.test.mjs
@@ -26,6 +26,7 @@ const source = {
   blocks: [
     {
       _key: "page-header-fha",
+      _type: "pageHeader",
       statistics: [
         { _key: "stat-down" },
         { _key: "stat-score" },
@@ -34,11 +35,19 @@ const source = {
     },
     {
       _key: "chapter-what-it-is",
+      _type: "editorialChapter",
       richText: [paragraph("what-p1", "old"), paragraph("what-p2", "old")],
-      supportingContent: [{ _key: "impact-down-payment", statement: "$14,000" }],
+      supportingContent: [
+        {
+          _key: "impact-down-payment",
+          _type: "impactStatement",
+          statement: "$14,000",
+        },
+      ],
     },
     {
       _key: "table-fha-vs-conventional",
+      _type: "comparisonTable",
       table: {
         rows: ["row-down", "row-credit", "row-mi", "row-seller", "row-best"].map(
           (_key) => ({ _key, cells: ["old", "old", "old"] }),
@@ -47,12 +56,14 @@ const source = {
     },
     {
       _key: "benefit-cards-advantages",
+      _type: "benefitCards",
       cards: ["adv-down", "adv-gift", "adv-credit", "adv-seller", "adv-prepay"].map(
         (_key) => ({ _key, title: "old", body: [paragraph(`${_key}-p`, "old")] }),
       ),
     },
     {
       _key: "loan-requirements",
+      _type: "loanRequirements",
       chapters: [
         {
           _key: "credit",
@@ -64,6 +75,7 @@ const source = {
           evidence: [
             {
               _key: "money-stats",
+              _type: "requirementStatRow",
               stats: [{ _key: "stat-gift" }],
             },
           ],
@@ -74,6 +86,7 @@ const source = {
           evidence: [
             {
               _key: "mip-tiers",
+              _type: "requirementTierList",
               tiers: [{ _key: "tier-duration" }],
             },
           ],
@@ -82,15 +95,18 @@ const source = {
     },
     {
       _key: "chapter-home-in-five",
+      _type: "editorialChapter",
       richText: [paragraph("hi5-p1", "old"), paragraph("hi5-p2", "old")],
-      supportingContent: [{ _key: "impact-hi5" }],
+      supportingContent: [{ _key: "impact-hi5", _type: "impactStatement" }],
     },
     {
       _key: "fha-faq",
+      _type: "faqAccordion",
       faqs: FAQ_IDS.map((_ref) => ({ _key: `ref-${_ref}`, _ref, _type: "reference" })),
     },
     {
       _key: "advisor-cta-why-fha",
+      _type: "advisorCta",
       richText: [paragraph("why-p1", "old"), paragraph("why-p2", "old")],
       buttons: [
         { _key: "apply", url: { internal: { _ref: "apply" } } },

--- a/studio/scripts/revise-fha-loan-page.ts
+++ b/studio/scripts/revise-fha-loan-page.ts
@@ -2,39 +2,15 @@ import { pathToFileURL } from "node:url";
 import { isDeepStrictEqual } from "node:util";
 import type { Patch } from "@sanity/client";
 import { getCliClient } from "sanity/cli";
+import type { Faq, Page, SimpleRichText } from "../../frontend/sanity.types";
 
 const API_VERSION = "2026-09-03";
 const DATASET = "development";
 const PAGE_ID = "fhaLoan";
 const EXPECTED_SLUG = "/phoenix-fha-loan";
 
-type RichTextBlock = {
-  _key: string;
-  _type: "block";
-  children: Array<{
-    _key: string;
-    _type: "span";
-    marks: string[];
-    text: string;
-  }>;
-  markDefs: unknown[];
-  style: string;
-};
-
-type SanityDocument = {
-  _id: string;
-  _rev: string;
-  _type: string;
-  body?: unknown;
-  [key: string]: unknown;
-};
-
-type PageDocument = SanityDocument & {
-  blocks?: Array<Record<string, any>>;
-  description?: string;
-  meta?: Record<string, unknown>;
-  slug?: { current?: string };
-};
+type PageBlock = NonNullable<Page["blocks"]>[number];
+type RichTextBlock = SimpleRichText[number];
 
 const FAQ_COPY: Record<string, string[]> = {
   "faq-fha-what-is-it": [
@@ -82,24 +58,53 @@ function paragraph(key: string, text: string): RichTextBlock {
   };
 }
 
-function requiredByKey(
-  items: Array<Record<string, any>>,
+function requiredByKey<Item extends { _key: string }>(
+  items: Item[] | undefined,
   key: string,
-): Record<string, any> {
+): Item {
+  if (!Array.isArray(items)) throw new Error(`Missing array for ${key}`);
   const item = items.find((candidate) => candidate._key === key);
   if (!item) throw new Error(`Missing array item ${key}`);
   return item;
 }
 
-function replaceParagraph(container: Record<string, any>, key: string, text: string) {
+function requiredPageBlock<Type extends PageBlock["_type"]>(
+  items: Page["blocks"],
+  key: string,
+  type: Type,
+): Extract<PageBlock, { _type: Type }> {
+  const item = requiredByKey(items, key) as PageBlock;
+  if (item._type !== type) {
+    throw new Error(`Expected ${key} to have type ${type}`);
+  }
+  return item as Extract<PageBlock, { _type: Type }>;
+}
+
+function requiredTypedItem<
+  Item extends { _key: string; _type: string },
+  Type extends Item["_type"],
+>(items: Item[] | undefined, key: string, type: Type): Extract<Item, { _type: Type }> {
+  const item = requiredByKey(items, key) as Item;
+  if (item._type !== type) {
+    throw new Error(`Expected ${key} to have type ${type}`);
+  }
+  return item as Extract<Item, { _type: Type }>;
+}
+
+type RichTextContainer = {
+  richText?: Array<{ _key: string }>;
+  body?: Array<{ _key: string }>;
+};
+
+function replaceParagraph(container: RichTextContainer, key: string, text: string) {
   const richText = container.richText ?? container.body;
   if (!Array.isArray(richText)) throw new Error(`Missing rich text for ${key}`);
-  const index = richText.findIndex((item: RichTextBlock) => item._key === key);
+  const index = richText.findIndex((item) => item._key === key);
   if (index === -1) throw new Error(`Missing paragraph ${key}`);
   richText[index] = paragraph(key, text);
 }
 
-export function validatePage(document: PageDocument | undefined) {
+export function validatePage(document: Page | Faq | undefined) {
   if (!document) return `Document ${PAGE_ID} does not exist`;
   if (document._id !== PAGE_ID || document._type !== "page") {
     return `Expected the published page document with ID ${PAGE_ID}`;
@@ -112,12 +117,12 @@ export function validatePage(document: PageDocument | undefined) {
   return undefined;
 }
 
-export function buildPageMutation(document: PageDocument) {
+export function buildPageMutation(document: Page) {
   const validationError = validatePage(document);
   if (validationError) throw new Error(validationError);
 
   const blocks = structuredClone(document.blocks!);
-  const header = requiredByKey(blocks, "page-header-fha");
+  const header = requiredPageBlock(blocks, "page-header-fha", "pageHeader");
   header.description =
     "FHA loans can offer a smaller down payment and more flexible credit guidelines than some conventional loans. We can help you compare the full cost, including mortgage insurance, for a Phoenix-area home.";
   const downStat = requiredByKey(header.statistics, "stat-down");
@@ -132,7 +137,7 @@ export function buildPageMutation(document: PageDocument) {
   sellerStat.description =
     "Seller contributions depend on the costs and current FHA rules.";
 
-  const basics = requiredByKey(blocks, "chapter-what-it-is");
+  const basics = requiredPageBlock(blocks, "chapter-what-it-is", "editorialChapter");
   replaceParagraph(
     basics,
     "what-p1",
@@ -143,13 +148,21 @@ export function buildPageMutation(document: PageDocument) {
     "what-p2",
     "FHA guidelines can allow a smaller down payment and more flexible credit review than some conventional loans. FHA mortgage insurance adds an upfront cost and an annual premium, so we compare the full payment and long-term cost before you choose.",
   );
-  requiredByKey(basics.supportingContent, "impact-down-payment").description =
+  requiredTypedItem(
+    basics.supportingContent,
+    "impact-down-payment",
+    "impactStatement",
+  ).description =
     "This example uses the 3.5% FHA minimum for a borrower who meets the credit and underwriting requirements. The final amount depends on your price, loan, and approval.";
 
-  const comparison = requiredByKey(blocks, "table-fha-vs-conventional");
+  const comparison = requiredPageBlock(
+    blocks,
+    "table-fha-vs-conventional",
+    "comparisonTable",
+  );
   comparison.intro =
     "FHA and conventional loans fit different borrower profiles. Compare the down payment, credit rules, mortgage insurance, seller contributions, rate, and total cost for the options you qualify for.";
-  const rows = comparison.table.rows;
+  const rows = comparison.table?.rows;
   requiredByKey(rows, "row-down").cells = [
     "Minimum down payment",
     "3.5% at 580 or higher; 10% at 500 to 579 under FHA guidelines. Lender rules apply.",
@@ -176,7 +189,11 @@ export function buildPageMutation(document: PageDocument) {
     "Buyers who qualify for its pricing and mortgage-insurance terms.",
   ];
 
-  const advantages = requiredByKey(blocks, "benefit-cards-advantages");
+  const advantages = requiredPageBlock(
+    blocks,
+    "benefit-cards-advantages",
+    "benefitCards",
+  );
   advantages.intro =
     "FHA guidelines can reduce the cash and credit barriers to buying a home. Your lender still reviews the full application and property.";
   const advantageCards = advantages.cards;
@@ -212,7 +229,7 @@ export function buildPageMutation(document: PageDocument) {
     "Extra principal payments can build equity faster. A later refinance depends on your finances, home value, rates, costs, and approval.",
   );
 
-  const requirements = requiredByKey(blocks, "loan-requirements");
+  const requirements = requiredPageBlock(blocks, "loan-requirements", "loanRequirements");
   requirements.intro =
     "FHA guidelines can allow a lower down payment and lower credit scores than some conventional loans. Approval still depends on your income, debts, funds, credit history, the property, and lender requirements.";
   const creditChapter = requiredByKey(requirements.chapters, "credit");
@@ -232,7 +249,11 @@ export function buildPageMutation(document: PageDocument) {
     "FHA guidelines allow 3.5% down with a score of 580 or higher. Eligible gift funds may cover the required down payment when they meet FHA source and documentation rules. Seller contributions may help with eligible closing costs.",
   );
   const giftStat = requiredByKey(
-    requiredByKey(moneyChapter.evidence, "money-stats").stats,
+    requiredTypedItem(
+      moneyChapter.evidence,
+      "money-stats",
+      "requirementStatRow",
+    ).stats,
     "stat-gift",
   );
   giftStat.label = "Eligible gift funds allowed";
@@ -247,7 +268,11 @@ export function buildPageMutation(document: PageDocument) {
     "FHA loans have an upfront mortgage insurance premium and an annual premium that is usually divided across monthly payments. Annual MIP generally lasts 11 years when the original loan-to-value ratio is 90% or less, and for the loan term when it is above 90%. A refinance creates a new loan and depends on approval, rates, costs, and terms.",
   );
   requiredByKey(
-    requiredByKey(insuranceChapter.evidence, "mip-tiers").tiers,
+    requiredTypedItem(
+      insuranceChapter.evidence,
+      "mip-tiers",
+      "requirementTierList",
+    ).tiers,
     "tier-duration",
   ).value = "11 years or loan term";
   insuranceChapter.note =
@@ -255,7 +280,11 @@ export function buildPageMutation(document: PageDocument) {
   requirements.closingNote =
     "Some Phoenix-area buyers may qualify for down-payment assistance. Funding and terms change, so ask us to confirm what is open.";
 
-  const assistance = requiredByKey(blocks, "chapter-home-in-five");
+  const assistance = requiredPageBlock(
+    blocks,
+    "chapter-home-in-five",
+    "editorialChapter",
+  );
   assistance.title = "Could Home in Five help with upfront costs?";
   replaceParagraph(
     assistance,
@@ -267,16 +296,17 @@ export function buildPageMutation(document: PageDocument) {
     "hi5-p2",
     "The assistance amount, income limit, credit and debt-to-income rules, education requirement, interest rate, second-lien payment and forgiveness terms, and funding availability depend on the product and date. Ask our team to confirm which options are open and whether you qualify.",
   );
-  const assistanceImpact = requiredByKey(
+  const assistanceImpact = requiredTypedItem(
     assistance.supportingContent,
     "impact-hi5",
+    "impactStatement",
   );
   assistanceImpact.statement = "Program-specific";
   assistanceImpact.label = "assistance and second-lien terms";
   assistanceImpact.description =
     "There is no single Home in Five percentage, income cap, rate, payment, or forgiveness schedule. We will check current funding and explain the selected option before you decide.";
 
-  const advisor = requiredByKey(blocks, "advisor-cta-why-fha");
+  const advisor = requiredPageBlock(blocks, "advisor-cta-why-fha", "advisorCta");
   advisor.title = "Your Phoenix FHA loan team";
   replaceParagraph(
     advisor,
@@ -303,7 +333,7 @@ export function buildPageMutation(document: PageDocument) {
   };
 }
 
-export function buildFaqMutation(document: SanityDocument) {
+export function buildFaqMutation(document: Page | Faq) {
   const copy = FAQ_COPY[document._id];
   if (!copy) throw new Error(`Unexpected FAQ document ${document._id}`);
   if (document._type !== "faq") throw new Error(`${document._id} is not an FAQ`);
@@ -317,10 +347,22 @@ export function buildFaqMutation(document: SanityDocument) {
   };
 }
 
-function isPageApplied(document: PageDocument, mutation: ReturnType<typeof buildPageMutation>) {
-  return Object.entries(mutation.set).every(([field, value]) =>
-    isDeepStrictEqual(document[field], value),
+function isPageApplied(document: Page, mutation: ReturnType<typeof buildPageMutation>) {
+  return (
+    isDeepStrictEqual(document.blocks, mutation.set.blocks) &&
+    isDeepStrictEqual(document.description, mutation.set.description) &&
+    isDeepStrictEqual(document.meta, mutation.set.meta)
   );
+}
+
+function requirePage(document: Page | Faq | undefined): Page {
+  const validationError = validatePage(document);
+  if (validationError) throw new Error(validationError);
+  return document as Page;
+}
+
+function faqBody(document: Page | Faq | undefined): Faq["body"] | undefined {
+  return document?._type === "faq" ? document.body : undefined;
 }
 
 async function main() {
@@ -342,32 +384,32 @@ async function main() {
   }
 
   const ids = [PAGE_ID, ...FAQ_IDS];
-  const documents = await client.fetch<SanityDocument[]>(
+  const documents = await client.fetch<Array<Page | Faq>>(
     `*[_id in $ids || _id in $draftIds]`,
     { ids, draftIds: ids.map((id) => `drafts.${id}`) },
   );
-  const drafts = documents.filter((document: SanityDocument) =>
+  const drafts = documents.filter((document: Page | Faq) =>
     document._id.startsWith("drafts."),
   );
   if (drafts.length) {
     throw new Error(
-      `Refusing to overwrite existing drafts: ${drafts.map((draft: SanityDocument) => draft._id).join(", ")}`,
+      `Refusing to overwrite existing drafts: ${drafts.map((draft: Page | Faq) => draft._id).join(", ")}`,
     );
   }
-  const byId = new Map<string, SanityDocument>(
-    documents.map((document: SanityDocument) => [document._id, document]),
+  const byId = new Map<string, Page | Faq>(
+    documents.map((document: Page | Faq) => [document._id, document]),
   );
-  const page = byId.get(PAGE_ID) as PageDocument | undefined;
-  const pageMutation = buildPageMutation(page as PageDocument);
+  const page = requirePage(byId.get(PAGE_ID));
+  const pageMutation = buildPageMutation(page);
   const faqMutations = FAQ_IDS.map((id) => {
     const document = byId.get(id);
     if (!document) throw new Error(`Missing FAQ document ${id}`);
     return buildFaqMutation(document);
   });
   const alreadyApplied =
-    isPageApplied(page as PageDocument, pageMutation) &&
+    isPageApplied(page, pageMutation) &&
     faqMutations.every((mutation) =>
-      isDeepStrictEqual(byId.get(mutation.id)?.body, mutation.set.body),
+      isDeepStrictEqual(faqBody(byId.get(mutation.id)), mutation.set.body),
     );
 
   console.log(
@@ -399,22 +441,22 @@ async function main() {
   }
 
   const [rawAfter, publishedAfter] = await Promise.all([
-    client.fetch<SanityDocument[]>(`*[_id in $ids]`, { ids }),
-    publishedClient.fetch<SanityDocument[]>(`*[_id in $ids]`, { ids }),
+    client.fetch<Array<Page | Faq>>(`*[_id in $ids]`, { ids }),
+    publishedClient.fetch<Array<Page | Faq>>(`*[_id in $ids]`, { ids }),
   ]);
   for (const [perspective, after] of [
     ["raw", rawAfter],
     ["published", publishedAfter],
   ] as const) {
-    const afterById = new Map<string, SanityDocument>(
-      after.map((document: SanityDocument) => [document._id, document]),
+    const afterById = new Map<string, Page | Faq>(
+      after.map((document: Page | Faq) => [document._id, document]),
     );
-    const pageAfter = afterById.get(PAGE_ID) as PageDocument | undefined;
-    if (!pageAfter || !isPageApplied(pageAfter, pageMutation)) {
+    const pageAfter = requirePage(afterById.get(PAGE_ID));
+    if (!isPageApplied(pageAfter, pageMutation)) {
       throw new Error(`Verification failed for the FHA page in ${perspective}`);
     }
     for (const mutation of faqMutations) {
-      if (!isDeepStrictEqual(afterById.get(mutation.id)?.body, mutation.set.body)) {
+      if (!isDeepStrictEqual(faqBody(afterById.get(mutation.id)), mutation.set.body)) {
         throw new Error(`Verification failed for ${mutation.id} in ${perspective}`);
       }
     }

--- a/studio/scripts/revise-fha-loan-page.ts
+++ b/studio/scripts/revise-fha-loan-page.ts
@@ -1,0 +1,444 @@
+import { pathToFileURL } from "node:url";
+import { isDeepStrictEqual } from "node:util";
+import type { Patch } from "@sanity/client";
+import { getCliClient } from "sanity/cli";
+
+const API_VERSION = "2026-09-03";
+const DATASET = "development";
+const PAGE_ID = "fhaLoan";
+const EXPECTED_SLUG = "/phoenix-fha-loan";
+
+type RichTextBlock = {
+  _key: string;
+  _type: "block";
+  children: Array<{
+    _key: string;
+    _type: "span";
+    marks: string[];
+    text: string;
+  }>;
+  markDefs: unknown[];
+  style: string;
+};
+
+type SanityDocument = {
+  _id: string;
+  _rev: string;
+  _type: string;
+  body?: unknown;
+  [key: string]: unknown;
+};
+
+type PageDocument = SanityDocument & {
+  blocks?: Array<Record<string, any>>;
+  description?: string;
+  meta?: Record<string, unknown>;
+  slug?: { current?: string };
+};
+
+const FAQ_COPY: Record<string, string[]> = {
+  "faq-fha-what-is-it": [
+    "An FHA loan is a mortgage issued by an approved lender and insured by the Federal Housing Administration. You can use an FHA program to buy, refinance, or improve an eligible primary residence, subject to program and lender rules.",
+    "FHA guidelines can allow a smaller down payment and more flexible credit review than some conventional loans. Mortgage insurance adds cost, so we compare both options before you choose.",
+  ],
+  "faq-fha-down-payment": [
+    "FHA guidelines allow a 3.5% minimum down payment for borrowers with a credit score of 580 or higher. Scores from 500 to 579 require at least 10% down. Lenders can set higher requirements, and your full application and the property still need approval.",
+    "Eligible gift funds may cover the required down payment when the donor, transfer, and gift letter meet FHA documentation rules. Some Maricopa County buyers may also qualify for assistance. Program terms and funding change, so ask us to confirm what is open before you make a plan.",
+  ],
+  "faq-fha-credit-score": [
+    "FHA guidelines permit scores from 500. A score from 500 to 579 requires at least 10% down, while a score of 580 or higher permits 3.5% down. Lenders can require a higher score and must review your income, debts, funds, credit history, and property.",
+    "A bankruptcy or foreclosure does not always rule out an FHA loan. Waiting periods and other requirements apply. We can review your current position and explain the next step.",
+  ],
+  "faq-fha-mip-vs-pmi": [
+    "FHA loans have an upfront mortgage insurance premium and an annual premium that is usually divided across monthly payments. Annual MIP generally lasts 11 years when the original loan-to-value ratio is 90% or less, and for the loan term when it is above 90%.",
+    "Conventional PMI follows different rules and may be cancellable. We can compare the insurance cost and duration for the loan options you qualify for.",
+  ],
+  "faq-fha-first-time-buyers": [
+    "No. FHA loans are available to eligible first-time and repeat buyers. The home must meet FHA requirements and be your primary residence.",
+    "Your loan still depends on credit, income, debts, funds, property review, and lender approval. We can compare FHA and conventional options for your situation.",
+  ],
+  "faq-fha-refinance-later": [
+    "You can refinance an FHA loan if you qualify for a new loan. A refinance may change or remove mortgage insurance, but it also brings a new rate, payment, closing costs, and approval. We compare the savings with the cost and break-even period before recommending a change.",
+    "You can also make extra principal payments. Check your loan documents and servicer instructions before you do.",
+  ],
+};
+
+export const FAQ_IDS = Object.keys(FAQ_COPY);
+
+function paragraph(key: string, text: string): RichTextBlock {
+  return {
+    _key: key,
+    _type: "block",
+    children: [
+      {
+        _key: `${key}-span`,
+        _type: "span",
+        marks: [],
+        text,
+      },
+    ],
+    markDefs: [],
+    style: "normal",
+  };
+}
+
+function requiredByKey(
+  items: Array<Record<string, any>>,
+  key: string,
+): Record<string, any> {
+  const item = items.find((candidate) => candidate._key === key);
+  if (!item) throw new Error(`Missing array item ${key}`);
+  return item;
+}
+
+function replaceParagraph(container: Record<string, any>, key: string, text: string) {
+  const richText = container.richText ?? container.body;
+  if (!Array.isArray(richText)) throw new Error(`Missing rich text for ${key}`);
+  const index = richText.findIndex((item: RichTextBlock) => item._key === key);
+  if (index === -1) throw new Error(`Missing paragraph ${key}`);
+  richText[index] = paragraph(key, text);
+}
+
+export function validatePage(document: PageDocument | undefined) {
+  if (!document) return `Document ${PAGE_ID} does not exist`;
+  if (document._id !== PAGE_ID || document._type !== "page") {
+    return `Expected the published page document with ID ${PAGE_ID}`;
+  }
+  if (!document._rev) return "The current page revision is required";
+  if (document.slug?.current !== EXPECTED_SLUG) {
+    return `slug.current must be ${EXPECTED_SLUG}`;
+  }
+  if (!Array.isArray(document.blocks)) return "The page blocks are required";
+  return undefined;
+}
+
+export function buildPageMutation(document: PageDocument) {
+  const validationError = validatePage(document);
+  if (validationError) throw new Error(validationError);
+
+  const blocks = structuredClone(document.blocks!);
+  const header = requiredByKey(blocks, "page-header-fha");
+  header.description =
+    "FHA loans can offer a smaller down payment and more flexible credit guidelines than some conventional loans. We can help you compare the full cost, including mortgage insurance, for a Phoenix-area home.";
+  const downStat = requiredByKey(header.statistics, "stat-down");
+  downStat.description =
+    "FHA minimum for scores of 580 or higher. Lender requirements also apply.";
+  const scoreStat = requiredByKey(header.statistics, "stat-score");
+  scoreStat.value = "500 FHA minimum";
+  scoreStat.description =
+    "Lenders can require a higher score and full qualification.";
+  const sellerStat = requiredByKey(header.statistics, "stat-seller");
+  sellerStat.value = "May be allowed";
+  sellerStat.description =
+    "Seller contributions depend on the costs and current FHA rules.";
+
+  const basics = requiredByKey(blocks, "chapter-what-it-is");
+  replaceParagraph(
+    basics,
+    "what-p1",
+    "An FHA loan is issued by an approved lender and insured by the Federal Housing Administration. FHA sets program rules, while the lender reviews your full application and the property.",
+  );
+  replaceParagraph(
+    basics,
+    "what-p2",
+    "FHA guidelines can allow a smaller down payment and more flexible credit review than some conventional loans. FHA mortgage insurance adds an upfront cost and an annual premium, so we compare the full payment and long-term cost before you choose.",
+  );
+  requiredByKey(basics.supportingContent, "impact-down-payment").description =
+    "This example uses the 3.5% FHA minimum for a borrower who meets the credit and underwriting requirements. The final amount depends on your price, loan, and approval.";
+
+  const comparison = requiredByKey(blocks, "table-fha-vs-conventional");
+  comparison.intro =
+    "FHA and conventional loans fit different borrower profiles. Compare the down payment, credit rules, mortgage insurance, seller contributions, rate, and total cost for the options you qualify for.";
+  const rows = comparison.table.rows;
+  requiredByKey(rows, "row-down").cells = [
+    "Minimum down payment",
+    "3.5% at 580 or higher; 10% at 500 to 579 under FHA guidelines. Lender rules apply.",
+    "Some programs allow 3%; eligibility and lender rules vary.",
+  ];
+  requiredByKey(rows, "row-credit").cells = [
+    "Credit score floor",
+    "FHA permits 500; lenders can require higher.",
+    "Varies by program and lender.",
+  ];
+  requiredByKey(rows, "row-mi").cells = [
+    "Mortgage insurance",
+    "Upfront and annual MIP. Annual MIP generally lasts 11 years or the loan term, based on original loan-to-value ratio.",
+    "PMI may apply below 20% down; cancellation follows the loan terms and federal rules.",
+  ];
+  requiredByKey(rows, "row-seller").cells = [
+    "Seller-paid closing costs",
+    "May be allowed for eligible costs, subject to FHA limits.",
+    "Limits vary by down payment, occupancy, and program.",
+  ];
+  requiredByKey(rows, "row-best").cells = [
+    "May fit",
+    "Buyers with limited savings or lower credit scores.",
+    "Buyers who qualify for its pricing and mortgage-insurance terms.",
+  ];
+
+  const advantages = requiredByKey(blocks, "benefit-cards-advantages");
+  advantages.intro =
+    "FHA guidelines can reduce the cash and credit barriers to buying a home. Your lender still reviews the full application and property.";
+  const advantageCards = advantages.cards;
+  replaceParagraph(
+    requiredByKey(advantageCards, "adv-down"),
+    "adv-down-p",
+    "FHA guidelines allow a 3.5% minimum down payment with a credit score of 580 or higher. Scores from 500 to 579 require at least 10% down. Lenders can set higher requirements.",
+  );
+  const giftCard = requiredByKey(advantageCards, "adv-gift");
+  giftCard.title = "Eligible gift funds can help";
+  replaceParagraph(
+    giftCard,
+    "adv-gift-p",
+    "Gift funds may cover the required down payment when the donor, transfer, and gift letter meet FHA rules. A gift cannot require repayment.",
+  );
+  const creditCard = requiredByKey(advantageCards, "adv-credit");
+  creditCard.title = "FHA permits scores from 500";
+  replaceParagraph(
+    creditCard,
+    "adv-credit-p",
+    "A score from 500 to 579 requires at least 10% down under FHA guidelines. A score of 580 or higher permits 3.5% down. Your lender can require a higher score and must approve the full loan.",
+  );
+  replaceParagraph(
+    requiredByKey(advantageCards, "adv-seller"),
+    "adv-seller-p",
+    "FHA rules may allow seller contributions toward eligible costs. The amount depends on the contract, appraisal, and current FHA limits.",
+  );
+  const prepayCard = requiredByKey(advantageCards, "adv-prepay");
+  prepayCard.title = "You can pay principal faster";
+  replaceParagraph(
+    prepayCard,
+    "adv-prepay-p",
+    "Extra principal payments can build equity faster. A later refinance depends on your finances, home value, rates, costs, and approval.",
+  );
+
+  const requirements = requiredByKey(blocks, "loan-requirements");
+  requirements.intro =
+    "FHA guidelines can allow a lower down payment and lower credit scores than some conventional loans. Approval still depends on your income, debts, funds, credit history, the property, and lender requirements.";
+  const creditChapter = requiredByKey(requirements.chapters, "credit");
+  creditChapter.title = "A lower program floor, with full lender review";
+  replaceParagraph(
+    creditChapter,
+    "credit-p1",
+    "FHA guidelines permit scores from 500, but lenders can set higher minimums. Your score affects the minimum down payment, and the lender reviews your full credit history. Bankruptcy and foreclosure waiting periods may apply.",
+  );
+  creditChapter.note =
+    "FHA down-payment tiers apply only when the borrower and property meet all other requirements.";
+  const moneyChapter = requiredByKey(requirements.chapters, "money-up-front");
+  moneyChapter.title = "A 3.5% minimum may be possible";
+  replaceParagraph(
+    moneyChapter,
+    "money-p1",
+    "FHA guidelines allow 3.5% down with a score of 580 or higher. Eligible gift funds may cover the required down payment when they meet FHA source and documentation rules. Seller contributions may help with eligible closing costs.",
+  );
+  const giftStat = requiredByKey(
+    requiredByKey(moneyChapter.evidence, "money-stats").stats,
+    "stat-gift",
+  );
+  giftStat.label = "Eligible gift funds allowed";
+  giftStat.value = "Allowed";
+  const insuranceChapter = requiredByKey(
+    requirements.chapters,
+    "mortgage-insurance",
+  );
+  replaceParagraph(
+    insuranceChapter,
+    "mip-p1",
+    "FHA loans have an upfront mortgage insurance premium and an annual premium that is usually divided across monthly payments. Annual MIP generally lasts 11 years when the original loan-to-value ratio is 90% or less, and for the loan term when it is above 90%. A refinance creates a new loan and depends on approval, rates, costs, and terms.",
+  );
+  requiredByKey(
+    requiredByKey(insuranceChapter.evidence, "mip-tiers").tiers,
+    "tier-duration",
+  ).value = "11 years or loan term";
+  insuranceChapter.note =
+    "We can compare FHA's full cost with conventional options for your profile.";
+  requirements.closingNote =
+    "Some Phoenix-area buyers may qualify for down-payment assistance. Funding and terms change, so ask us to confirm what is open.";
+
+  const assistance = requiredByKey(blocks, "chapter-home-in-five");
+  assistance.title = "Could Home in Five help with upfront costs?";
+  replaceParagraph(
+    assistance,
+    "hi5-p1",
+    "Home in Five may offer down-payment and closing-cost assistance with an eligible first mortgage for a home in Maricopa County. Both first-time and repeat buyers may be eligible. Program funding and loan options can change.",
+  );
+  replaceParagraph(
+    assistance,
+    "hi5-p2",
+    "The assistance amount, income limit, credit and debt-to-income rules, education requirement, interest rate, second-lien payment and forgiveness terms, and funding availability depend on the product and date. Ask our team to confirm which options are open and whether you qualify.",
+  );
+  const assistanceImpact = requiredByKey(
+    assistance.supportingContent,
+    "impact-hi5",
+  );
+  assistanceImpact.statement = "Program-specific";
+  assistanceImpact.label = "assistance and second-lien terms";
+  assistanceImpact.description =
+    "There is no single Home in Five percentage, income cap, rate, payment, or forgiveness schedule. We will check current funding and explain the selected option before you decide.";
+
+  const advisor = requiredByKey(blocks, "advisor-cta-why-fha");
+  advisor.title = "Your Phoenix FHA loan team";
+  replaceParagraph(
+    advisor,
+    "why-p1",
+    "An FHA loan can be useful when a conventional loan does not fit your savings or credit profile. Our team will compare the down payment, mortgage insurance, rate, payment, and long-term cost with you.",
+  );
+  replaceParagraph(
+    advisor,
+    "why-p2",
+    "Call, send a message, or visit our Phoenix office. We will explain the requirements and help you decide whether FHA fits your plans.",
+  );
+
+  const description =
+    "Learn how FHA loans work for Phoenix-area homebuyers, including down payments, credit, mortgage insurance, refinancing, and current assistance options.";
+
+  return {
+    id: document._id,
+    ifRevisionID: document._rev,
+    set: {
+      blocks,
+      description,
+      meta: { ...document.meta, description },
+    },
+  };
+}
+
+export function buildFaqMutation(document: SanityDocument) {
+  const copy = FAQ_COPY[document._id];
+  if (!copy) throw new Error(`Unexpected FAQ document ${document._id}`);
+  if (document._type !== "faq") throw new Error(`${document._id} is not an FAQ`);
+  if (!document._rev) throw new Error(`${document._id} has no revision`);
+  return {
+    id: document._id,
+    ifRevisionID: document._rev,
+    set: {
+      body: copy.map((text, index) => paragraph(`${document._id}-p${index}`, text)),
+    },
+  };
+}
+
+function isPageApplied(document: PageDocument, mutation: ReturnType<typeof buildPageMutation>) {
+  return Object.entries(mutation.set).every(([field, value]) =>
+    isDeepStrictEqual(document[field], value),
+  );
+}
+
+async function main() {
+  const apply = process.argv.includes("--apply");
+  const datasetFlag = process.argv.find((arg) => arg.startsWith("--dataset="));
+  const dataset = datasetFlag?.slice("--dataset=".length) ?? DATASET;
+  if (dataset !== DATASET) {
+    throw new Error(`Refusing to run outside the ${DATASET} dataset`);
+  }
+
+  const client = getCliClient({
+    apiVersion: API_VERSION,
+    dataset,
+    perspective: "raw",
+  });
+  const publishedClient = client.withConfig({ perspective: "published" });
+  if (client.config().dataset !== DATASET) {
+    throw new Error(`Refusing to run outside the ${DATASET} dataset`);
+  }
+
+  const ids = [PAGE_ID, ...FAQ_IDS];
+  const documents = await client.fetch<SanityDocument[]>(
+    `*[_id in $ids || _id in $draftIds]`,
+    { ids, draftIds: ids.map((id) => `drafts.${id}`) },
+  );
+  const drafts = documents.filter((document: SanityDocument) =>
+    document._id.startsWith("drafts."),
+  );
+  if (drafts.length) {
+    throw new Error(
+      `Refusing to overwrite existing drafts: ${drafts.map((draft: SanityDocument) => draft._id).join(", ")}`,
+    );
+  }
+  const byId = new Map<string, SanityDocument>(
+    documents.map((document: SanityDocument) => [document._id, document]),
+  );
+  const page = byId.get(PAGE_ID) as PageDocument | undefined;
+  const pageMutation = buildPageMutation(page as PageDocument);
+  const faqMutations = FAQ_IDS.map((id) => {
+    const document = byId.get(id);
+    if (!document) throw new Error(`Missing FAQ document ${id}`);
+    return buildFaqMutation(document);
+  });
+  const alreadyApplied =
+    isPageApplied(page as PageDocument, pageMutation) &&
+    faqMutations.every((mutation) =>
+      isDeepStrictEqual(byId.get(mutation.id)?.body, mutation.set.body),
+    );
+
+  console.log(
+    JSON.stringify(
+      {
+        dataset,
+        mode: apply ? "apply" : "dry-run",
+        pageId: PAGE_ID,
+        faqIds: FAQ_IDS,
+        alreadyApplied,
+      },
+      null,
+      2,
+    ),
+  );
+  if (!apply) return;
+
+  if (!alreadyApplied) {
+    const transaction = client.transaction();
+    transaction.patch(pageMutation.id, (patch: Patch) =>
+      patch.ifRevisionId(pageMutation.ifRevisionID).set(pageMutation.set),
+    );
+    for (const mutation of faqMutations) {
+      transaction.patch(mutation.id, (patch: Patch) =>
+        patch.ifRevisionId(mutation.ifRevisionID).set(mutation.set),
+      );
+    }
+    await transaction.commit({ visibility: "sync" });
+  }
+
+  const [rawAfter, publishedAfter] = await Promise.all([
+    client.fetch<SanityDocument[]>(`*[_id in $ids]`, { ids }),
+    publishedClient.fetch<SanityDocument[]>(`*[_id in $ids]`, { ids }),
+  ]);
+  for (const [perspective, after] of [
+    ["raw", rawAfter],
+    ["published", publishedAfter],
+  ] as const) {
+    const afterById = new Map<string, SanityDocument>(
+      after.map((document: SanityDocument) => [document._id, document]),
+    );
+    const pageAfter = afterById.get(PAGE_ID) as PageDocument | undefined;
+    if (!pageAfter || !isPageApplied(pageAfter, pageMutation)) {
+      throw new Error(`Verification failed for the FHA page in ${perspective}`);
+    }
+    for (const mutation of faqMutations) {
+      if (!isDeepStrictEqual(afterById.get(mutation.id)?.body, mutation.set.body)) {
+        throw new Error(`Verification failed for ${mutation.id} in ${perspective}`);
+      }
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        applied: alreadyApplied ? 0 : ids.length,
+        pageId: PAGE_ID,
+        faqCount: FAQ_IDS.length,
+        perspectives: ["published", "raw"],
+        targetDraftCount: 0,
+        verified: true,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
The published FHA page used one set of Home in Five figures even though current program options have different terms and availability. This could give Phoenix buyers false certainty about assistance.

This update preserves the established FHA page, six canonical FAQs, videos, and conversion routes. It replaces stale assistance claims with product-specific language, qualifies FHA guidance, aligns metadata and structured data, and adds a guarded, revision-safe Sanity update with publication evidence.

Checks:
- pnpm typecheck
- pnpm lint
- pnpm test, 448 tests passed
- published and raw Sanity verification, zero target drafts
- focused rendered metadata, links, FAQ, and JSON-LD checks

The shared preview could not complete a mobile resize or keyboard activation because those controls timed out. This limitation is recorded in the evidence file.

Closes #75