### PR TITLE
Add custom links to advisor CTA rich text

### DIFF
--- a/frontend/sanity.types.ts
+++ b/frontend/sanity.types.ts
@@ -239,11 +239,11 @@ export type AdvisorCta = {
     }>;
     style?: "normal" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "blockquote";
     listItem?: "bullet" | "number";
-    markDefs?: Array<{
-      href?: string;
-      _type: "link";
-      _key: string;
-    }>;
+    markDefs?: Array<
+      {
+        _key: string;
+      } & CustomLink
+    >;
     level?: number;
     _type: "block";
     _key: string;
@@ -1944,9 +1944,11 @@ export type BLOG_INDEX_QUERY_RESULT =
                 | "normal";
               listItem?: "bullet" | "number";
               markDefs: Array<{
-                href?: string;
-                _type: "link";
                 _key: string;
+                _type: "customLink";
+                customLink?: CustomUrl;
+                href: string | null | "/";
+                openInNewTab: boolean | null;
               }> | null;
               level?: number;
               _type: "block";
@@ -3231,9 +3233,11 @@ export type BLOG_INDEX_QUERY_RESULT =
                 | "normal";
               listItem?: "bullet" | "number";
               markDefs: Array<{
-                href?: string;
-                _type: "link";
                 _key: string;
+                _type: "customLink";
+                customLink?: CustomUrl;
+                href: string | null | "/";
+                openInNewTab: boolean | null;
               }> | null;
               level?: number;
               _type: "block";
@@ -4578,9 +4582,11 @@ export type BLOG_INDEX_QUERY_RESULT =
                 | "normal";
               listItem?: "bullet" | "number";
               markDefs: Array<{
-                href?: string;
-                _type: "link";
                 _key: string;
+                _type: "customLink";
+                customLink?: CustomUrl;
+                href: string | null | "/";
+                openInNewTab: boolean | null;
               }> | null;
               level?: number;
               _type: "block";
@@ -6178,9 +6184,11 @@ export type HOME_PAGE_QUERY_RESULT = {
             "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
           listItem?: "bullet" | "number";
           markDefs: Array<{
-            href?: string;
-            _type: "link";
             _key: string;
+            _type: "customLink";
+            customLink?: CustomUrl;
+            href: string | null | "/";
+            openInNewTab: boolean | null;
           }> | null;
           level?: number;
           _type: "block";
@@ -7568,9 +7576,11 @@ export type PAGE_QUERY_RESULT = {
             "blockquote" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "normal";
           listItem?: "bullet" | "number";
           markDefs: Array<{
-            href?: string;
-            _type: "link";
             _key: string;
+            _type: "customLink";
+            customLink?: CustomUrl;
+            href: string | null | "/";
+            openInNewTab: boolean | null;
           }> | null;
           level?: number;
           _type: "block";

--- a/studio/schema.json
+++ b/studio/schema.json
@@ -1379,31 +1379,16 @@
                     "of": {
                       "type": "object",
                       "attributes": {
-                        "href": {
+                        "_key": {
                           "type": "objectAttribute",
                           "value": {
                             "type": "string"
-                          },
-                          "optional": true
-                        },
-                        "_type": {
-                          "type": "objectAttribute",
-                          "value": {
-                            "type": "string",
-                            "value": "link"
                           }
                         }
                       },
                       "rest": {
-                        "type": "object",
-                        "attributes": {
-                          "_key": {
-                            "type": "objectAttribute",
-                            "value": {
-                              "type": "string"
-                            }
-                          }
-                        }
+                        "type": "inline",
+                        "name": "customLink"
                       }
                     }
                   },

--- a/studio/schemas/blocks/advisor-cta.ts
+++ b/studio/schemas/blocks/advisor-cta.ts
@@ -38,6 +38,7 @@ export default defineType({
               { title: "Strong", value: "strong" },
               { title: "Emphasis", value: "em" },
             ],
+            annotations: [defineArrayMember({ type: "customLink" })],
           },
         }),
       ],


### PR DESCRIPTION
## Summary

- Add custom link annotations to Advisor CTA rich text.
- Update generated Sanity schema and frontend types.

## Testing

- Not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rich-text content now supports custom links across advisor calls to action, blog content, home pages, and other pages.
  * Links can provide resolved destinations and indicate whether they open in a new browser tab.

* **Improvements**
  * Link handling is now more consistent across published content and editorial experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->